### PR TITLE
[#88676602] Parse tunit_metadata

### DIFF
--- a/memsource/lib/mxliff.py
+++ b/memsource/lib/mxliff.py
@@ -11,26 +11,30 @@ class MxliffParser(object):
         root = objectify.fromstring(resource)
         memsource_namespace = root.nsmap['m']
 
-        return [
-            self.parse_group(group, memsource_namespace) for group in root.file.body.getchildren()
-        ]
-
-    def parse_group(
-            self,
-            group: {objectify.ObjectifiedElement},
-            memsource_namespace: {str}
-    ) -> models.MxliffUnit:
-        def to_memsouce_key(s):
+        def to_memsouce_key(s: str) -> str:
             return '{{{}}}{}'.format(memsource_namespace, s)
 
+        self.score_key = to_memsouce_key('score')
+        self.gloss_score_key = to_memsouce_key('gross-score')
+        self.tunit_metadata_key = to_memsouce_key('tunit-metadata')
+        self.mark_key = to_memsouce_key('mark')
+        self.type_key = to_memsouce_key('type')
+        self.content_key = to_memsouce_key('content')
+
+        return [
+            self.parse_group(group) for group in root.file.body.getchildren()
+        ]
+
+    def parse_group(self, group: objectify.ObjectifiedElement) -> models.MxliffUnit:
         # Because we cannot write 'group.trans-unit'.
         trans_unit = getattr(group, 'trans-unit')
         source = {
             'id': trans_unit.attrib['id'],
-            'score': float(trans_unit.attrib[to_memsouce_key('score')]),
-            'gross_score': float(trans_unit.attrib[to_memsouce_key('gross-score')]),
+            'score': float(trans_unit.attrib[self.score_key]),
+            'gross_score': float(trans_unit.attrib[self.gloss_score_key]),
             'source': trans_unit.source.text,
             'target': trans_unit.target.text,
+            'tunit_metadata': self.parse_tunit_metadata(trans_unit),
         }
 
         for alt_trans in getattr(trans_unit, 'alt-trans'):
@@ -38,3 +42,16 @@ class MxliffParser(object):
             source[alt_trans.attrib['origin'].replace('-', '_')] = alt_trans.target.text
 
         return models.MxliffUnit(source)
+
+    def parse_tunit_metadata(self, trans_unit: objectify.ObjectifiedElement) -> list:
+        tunit_metadata = getattr(trans_unit, self.tunit_metadata_key, None)
+
+        # There is no meta data.
+        if tunit_metadata is None:
+            return []
+
+        return [{
+            'id': mark.attrib['id'],
+            'type': getattr(mark, self.type_key),
+            'content': getattr(mark, self.content_key),
+        } for mark in getattr(tunit_metadata, self.mark_key)]

--- a/test/api/test_job.py
+++ b/test/api/test_job.py
@@ -317,6 +317,7 @@ class TestApiJob(api_test.ApiTestCase):
             'target': None,
             'machine_trans': None,
             'memsource_tm': None,
+            'tunit_metadata': [],
         })
 
         self.assertIsInstance(returned_value[1], models.MxliffUnit)
@@ -328,6 +329,7 @@ class TestApiJob(api_test.ApiTestCase):
             'target': 'このライブラリはMemsourceのAPIをPython用にラップしています。',
             'machine_trans': 'This is machine translation.',
             'memsource_tm': 'This is memsource translation memory.',
+            'tunit_metadata': [],
         })
 
         mock_request.assert_called_with(

--- a/test/lib/mxliff/test_meta.mxliff
+++ b/test/lib/mxliff/test_meta.mxliff
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:m="http://www.memsource.com/mxlf/2.0" version="1.2" m:version="2.0" m:level="1">
+  <file original="test.txt" source-language="en" target-language="ja" datatype="x-undefined" m:task-id="fj4ewiofj3qowjfw">
+    <body>
+      <group id="0">
+        <trans-unit id="fj4ewiofj3qowjfw:0" xml:space="preserve" m:score="0.0" m:gross-score="0.0" m:trans-origin="null" m:confirmed="0" m:locked="false" m:para-id="0" m:created-at="0" m:created-by="" m:modified-at="0" m:modified-by="" m:level-edited="false">
+          <source>Hello World.</source>
+          <target/>
+          <alt-trans origin="machine-trans"><target/></alt-trans>
+          <alt-trans origin="memsource-tm"><target/></alt-trans>
+          <m:tunit-metadata>
+            <m:mark id="1">
+              <m:type>term</m:type>
+              <m:content>&lt;term&gt;This is term.&lt;/term&gt;</m:content>
+            </m:mark>
+            <m:mark id="2">
+              <m:type>bracket</m:type>
+              <m:content>&lt;bracket&gt;This is bracket.&lt;/bracket&gt;</m:content>
+            </m:mark>
+          </m:tunit-metadata>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/test/lib/mxliff/test_mxliff_parser.py
+++ b/test/lib/mxliff/test_mxliff_parser.py
@@ -26,6 +26,7 @@ class TestMxliffParser(unittest.TestCase):
             'target': None,
             'machine_trans': None,
             'memsource_tm': None,
+            'tunit_metadata': [],
         })
 
         self.assertIsInstance(mxliff_units[1], models.MxliffUnit)
@@ -37,4 +38,5 @@ class TestMxliffParser(unittest.TestCase):
             'target': 'このライブラリはMemsourceのAPIをPython用にラップしています。',
             'machine_trans': 'This is machine translation.',
             'memsource_tm': 'This is memsource translation memory.',
+            'tunit_metadata': [],
         })

--- a/test/lib/mxliff/test_mxliff_parser.py
+++ b/test/lib/mxliff/test_mxliff_parser.py
@@ -8,10 +8,14 @@ from memsource import models
 class TestMxliffParser(unittest.TestCase):
     def setUp(self):
         # Read test.mxliff file from same directory with this file.
-        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test.mxliff')) as f:
-            self.mxliff_text = f.read().encode('utf-8')
+        file_dir = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(file_dir, 'test.mxliff')) as f:
+            self.mxliff_text = f.read().encode()
 
-    def test_parse(self):
+        with open(os.path.join(file_dir, 'test_meta.mxliff')) as f:
+            self.mxliff_text_meta = f.read().encode()
+
+    def test_parse_no_meta(self):
         mxliff_units = MxliffParser().parse(self.mxliff_text)
 
         self.assertEqual(len(mxliff_units), 2)
@@ -39,4 +43,30 @@ class TestMxliffParser(unittest.TestCase):
             'machine_trans': 'This is machine translation.',
             'memsource_tm': 'This is memsource translation memory.',
             'tunit_metadata': [],
+        })
+
+    def test_parse_with_meta(self):
+        mxliff_units = MxliffParser().parse(self.mxliff_text_meta)
+
+        self.assertEqual(len(mxliff_units), 1)
+
+        self.assertIsInstance(mxliff_units[0], models.MxliffUnit)
+
+        self.assertEqual(mxliff_units[0], {
+            'id': 'fj4ewiofj3qowjfw:0',
+            'score': 0.0,
+            'gross_score': 0.0,
+            'source': 'Hello World.',
+            'target': None,
+            'machine_trans': None,
+            'memsource_tm': None,
+            'tunit_metadata': [{
+                'id': '1',
+                'type': 'term',
+                'content': '<term>This is term.</term>',
+            }, {
+                'id': '2',
+                'type': 'bracket',
+                'content': '<bracket>This is bracket.</bracket>',
+            }],
         })


### PR DESCRIPTION
Extend returning data with `tunit_metadata`.

```python
[
    {
        'target': '文章の頭',
        'tunit_metadata': [],
        'gross_score': 0.0,
        'machine_trans': None,
        'id': '2UeuHOPaMieDXkel:0',
        'score': 0.0,
        'memsource_tm': None,
        'source': 'This is in head of text.'
    }, {
        'target': '{1}文章の中間',
        'tunit_metadata': [
            {
                'id': '1',
                'type': 'gengo-term',
                'content': '<gengo-term>This is in gengo term.</gengo-term>'
            }
        ],
        'gross_score': 0.0,
        'machine_trans': None,
        'id': '2UeuHOPaMieDXkel:1',
        'score': 0.0,
        'memsource_tm': None,
        'source': '{1} This is in middle of text.'
    }, {
        'target': '文章の終わり',
        'tunit_metadata': [
            {
                'id': '2',
                'type': 'gengo-bracket',
                'content': '<gengo-bracket>This is in gengo bracket.</gengo-bracket>'
            }
        ],
        'gross_score': 0.0,
        'machine_trans': None,
        'id': '2UeuHOPaMieDXkel:2',
        'score': 0.0,
        'memsource_tm': None,
        'source': '{2} This is in tail of text.'
    }
]
```