### PR TITLE
[#98912898] Force use UTF-8 for writing a file

### DIFF
--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 __license__ = 'MIT'

--- a/memsource/api.py
+++ b/memsource/api.py
@@ -600,7 +600,7 @@ class Asynchronous(BaseApi):
         # uploading even if uploading failed.
         file_parent = os.path.dirname(file_path)
         os.makedirs(file_parent)
-        with open(file_path, 'w+') as f:
+        with io.open(file_path, 'w', encoding='utf-8') as f:
             f.write(text)
 
         try:

--- a/test/api/test_asynchronouse.py
+++ b/test/api/test_asynchronouse.py
@@ -258,7 +258,8 @@ class TestApiAsynchronous(api_test.ApiTestCase):
     @patch.object(io, 'open')
     @patch.object(uuid, 'uuid1')
     @patch.object(requests, 'request')
-    def test_create_job_from_text_no_callback(self, mock_request, mock_uuid1, mock_ioopen, mock_open):
+    def test_create_job_from_text_no_callback(
+            self, mock_request, mock_uuid1, mock_ioopen, mock_open):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
         text = 'This is a test text.'

--- a/test/api/test_asynchronouse.py
+++ b/test/api/test_asynchronouse.py
@@ -1,4 +1,5 @@
 import uuid
+import io
 import builtins
 from unittest.mock import PropertyMock
 from unittest.mock import patch
@@ -254,9 +255,10 @@ class TestApiAsynchronous(api_test.ApiTestCase):
         )
 
     @patch.object(builtins, 'open')
+    @patch.object(io, 'open')
     @patch.object(uuid, 'uuid1')
     @patch.object(requests, 'request')
-    def test_create_job_from_text_no_callback(self, mock_request, mock_uuid1, mock_open):
+    def test_create_job_from_text_no_callback(self, mock_request, mock_uuid1, mock_ioopen, mock_open):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
         text = 'This is a test text.'
@@ -302,15 +304,16 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-        mock_file.write.assert_called_with(text)
+        mock_ioopen().__enter__().write.assert_called_with(text)
         self.assertEqual(async_request.id, asynchronous_request_id)
         self.assertEqual(job_parts[0].id, 9371)
         self.assertEqual(job_parts[1].id, 9372)
 
     @patch.object(builtins, 'open')
+    @patch.object(io, 'open')
     @patch.object(uuid, 'uuid1')
     @patch.object(requests, 'request')
-    def test_create_job_from_text_callback(self, mock_request, mock_uuid1, mock_open):
+    def test_create_job_from_text_callback(self, mock_request, mock_uuid1, mock_ioopen, mock_open):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
         text = 'This is a test text.'
@@ -357,7 +360,7 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-        mock_file.write.assert_called_with(text)
+        mock_ioopen().__enter__().write.assert_called_with(text)
         self.assertEqual(async_request.id, asynchronous_request_id)
         self.assertEqual(job_parts[0].id, 9371)
         self.assertEqual(job_parts[1].id, 9372)


### PR DESCRIPTION
UTF-8 is not defaullt in Staging

```
Type "help", "copyright", "credits" or "license" for more information.
>>> with open('/tmp/a', 'w') as f: f.write('\xb4')
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character '\xb4' in position 0: ordinal not in range(128)
>>> import io
>>> with io.open('/tmp/a', 'w', encoding='utf-8') as f: f.write('\xb4')                                                                                                                                                                                                                                                        
... 
1
```