### PR TITLE
[#104391808] Handle non-json response

### DIFF
--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.0.6'
+__version__ = '0.0.7'
 __license__ = 'MIT'

--- a/memsource/api.py
+++ b/memsource/api.py
@@ -122,8 +122,17 @@ class BaseApi(object):
         if BaseApi.is_success(response.status_code):
             return response
 
+        # Usually Memsource returns JSON even if the response is error. But they returns
+        # "Too many requests.", It's not JSON.
+        try:
+            result_json = response.json()
+        except ValueError:
+            result_json = {
+                'errorCode': 'Non JSON response',
+                'errorDescription': 'Raw response {}'.format(response.text),
+            }
         raise exceptions.MemsourceApiException(
-            response.status_code, response.json(), self.last_url, self.last_params)
+            response.status_code, result_json, self.last_url, self.last_params)
 
     def _request(
             self,

--- a/test/api/test_asynchronouse.py
+++ b/test/api/test_asynchronouse.py
@@ -382,3 +382,19 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             exceptions.MemsourceUnsupportedFileException,
             lambda: self.asynchronous.createJobFromText(project_id, text, target_lang)
         )
+
+    @patch.object(requests, 'request')
+    def test_create_job_too_many_requests(self, mock_request):
+        text = 'This is a test text.'
+        target_lang = 'ja'
+        project_id = self.gen_random_int()
+
+        response = mock_request()
+        response.status_code = 429
+        response.json.side_effect = ValueError
+        response.text = "Too many requests."
+
+        self.assertRaises(
+            exceptions.MemsourceApiException,
+            lambda: self.asynchronous.createJobFromText(project_id, text, target_lang)
+        )


### PR DESCRIPTION
Memsource returns "Too many requests." in raw text.