### PR TITLE
Allow users to customize requests.Session

### DIFF
--- a/memsource/api.py
+++ b/memsource/api.py
@@ -1,14 +1,15 @@
-import requests
-import uuid
 import io
-import types
 import os
 import os.path
 import shutil
+import types
 import typing
+import uuid
 
-from . import constants, exceptions, models
-from .lib import mxliff
+import requests
+
+from memsource import constants, exceptions, models
+from memsource.lib import mxliff
 
 
 __all__ = ('Auth', 'Client', 'Domain', 'Project', 'Job', 'TranslationMemory', 'Asynchronous',

--- a/test/api/test_analysis.py
+++ b/test/api/test_analysis.py
@@ -9,7 +9,7 @@ class TestApiAnalysis(api_test.ApiTestCase):
         self.url_base = 'https://cloud1.memsource.com/web/api/v2/analyse'
         self.analysis = api.Analysis('token')
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -31,7 +31,7 @@ class TestApiAnalysis(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 

--- a/test/api/test_asynchronouse.py
+++ b/test/api/test_asynchronouse.py
@@ -35,7 +35,7 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             'endIndex': 14
         }]
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_pre_translate_no_callback(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -77,7 +77,7 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_pre_translate_callback(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -120,7 +120,7 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get_async_request(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -157,7 +157,7 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create_analysis_no_callback(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -203,7 +203,7 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create_analysis_callback(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -257,7 +257,7 @@ class TestApiAsynchronous(api_test.ApiTestCase):
     @patch.object(builtins, 'open')
     @patch.object(io, 'open')
     @patch.object(uuid, 'uuid1')
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create_job_from_text_no_callback(
             self, mock_request, mock_uuid1, mock_ioopen, mock_open):
         type(mock_request()).status_code = PropertyMock(return_value=200)
@@ -313,7 +313,7 @@ class TestApiAsynchronous(api_test.ApiTestCase):
     @patch.object(builtins, 'open')
     @patch.object(io, 'open')
     @patch.object(uuid, 'uuid1')
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create_job_from_text_callback(self, mock_request, mock_uuid1, mock_ioopen, mock_open):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -366,7 +366,7 @@ class TestApiAsynchronous(api_test.ApiTestCase):
         self.assertEqual(job_parts[0].id, 9371)
         self.assertEqual(job_parts[1].id, 9372)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create_job_from_text_failure(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -383,7 +383,7 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             lambda: self.asynchronous.createJobFromText(project_id, text, target_lang)
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create_job_too_many_requests(self, mock_request):
         text = 'This is a test text.'
         target_lang = 'ja'

--- a/test/api/test_client.py
+++ b/test/api/test_client.py
@@ -9,7 +9,7 @@ class TestApiClient(unittest.TestCase):
         self.url_base = 'https://cloud1.memsource.com/web/api/v2/client'
         self.client = api.Client(None)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create(self, mock_request):
         def test():
             mock_request.assert_called_with(
@@ -35,7 +35,7 @@ class TestApiClient(unittest.TestCase):
         self.client.create(client)
         test()
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get(self, mock_request):
         def test_called():
             mock_request.assert_called_with(
@@ -75,7 +75,7 @@ class TestApiClient(unittest.TestCase):
         self.assertEqual(r.id, client_id)
         self.assertEqual(r.name, client_name)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_list(self, mock_request):
         def test():
             mock_request.assert_called_with(
@@ -99,7 +99,7 @@ class TestApiClient(unittest.TestCase):
         self.client.list()
         test()
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_error_response(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=400)
 

--- a/test/api/test_domain.py
+++ b/test/api/test_domain.py
@@ -9,7 +9,7 @@ class TestApiDomain(unittest.TestCase):
         self.url_base = 'https://cloud1.memsource.com/web/api/v2/domain'
         self.domain = api.Domain(None)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create(self, mock_request):
         def test():
             mock_request.assert_called_with(
@@ -35,7 +35,7 @@ class TestApiDomain(unittest.TestCase):
         self.domain.create(domain)
         test()
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get(self, mock_request):
         def test():
             mock_request.assert_called_with(
@@ -61,7 +61,7 @@ class TestApiDomain(unittest.TestCase):
         self.domain.get(domain)
         test()
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_list(self, mock_request):
         def test():
             mock_request.assert_called_with(

--- a/test/api/test_job.py
+++ b/test/api/test_job.py
@@ -45,7 +45,7 @@ class TestApiJob(api_test.ApiTestCase):
             }]
         }
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
         mock_request().json.return_value = self.create_return_value
@@ -78,7 +78,7 @@ class TestApiJob(api_test.ApiTestCase):
             self.assertIsInstance(job_part, models.JobPart)
 
     @patch.object(uuid, 'uuid1')
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create_with_unsupported_file(self, mock_request, mock_uuid1):
         type(mock_request()).status_code = PropertyMock(return_value=200)
         mock_request().json.return_value = {
@@ -95,7 +95,7 @@ class TestApiJob(api_test.ApiTestCase):
         self.assertTrue(os.path.isfile(self.test_file_copy_path))
 
     @patch.object(uuid, 'uuid1')
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create_from_text(self, mock_request, mock_uuid1):
         type(mock_request()).status_code = PropertyMock(return_value=200)
         mock_request().json.return_value = self.create_return_value
@@ -128,7 +128,7 @@ class TestApiJob(api_test.ApiTestCase):
             self.assertIsInstance(job_part, models.JobPart)
 
     @patch.object(uuid, 'uuid1')
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test__create(self, mock_request, mock_uuid1):
         type(mock_request()).status_code = PropertyMock(return_value=200)
         file_name = 'filename.txt'
@@ -149,7 +149,7 @@ class TestApiJob(api_test.ApiTestCase):
         with open(self.test_file_copy_path) as f:
             self.assertEqual(f.read(), text)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_list_by_project(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -212,7 +212,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         self.assertEqual(len(returned_value), len(mock_request().json()))
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_pre_translate(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
         mock_request().json.return_value = {}
@@ -233,7 +233,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         self.assertIsNone(returned_value)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get_bilingual_file(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -264,7 +264,7 @@ class TestApiJob(api_test.ApiTestCase):
             stream=True
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get_bilingual_file_xml(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -291,7 +291,7 @@ class TestApiJob(api_test.ApiTestCase):
             stream=True
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get_bilingual_as_mxliff_units(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -344,7 +344,7 @@ class TestApiJob(api_test.ApiTestCase):
             stream=True
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get_segments(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -394,7 +394,7 @@ class TestApiJob(api_test.ApiTestCase):
         self.assertEqual('Hello World.', returned_value[0].source)
 
     @patch.object(uuid, 'uuid1')
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_upload_bilingual_file_from_xml(self, mock_request, mock_uuid1):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -413,7 +413,7 @@ class TestApiJob(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get_completed_file_text(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -437,7 +437,7 @@ class TestApiJob(api_test.ApiTestCase):
             stream=True
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -462,7 +462,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         self.assertEqual('NEW', returned_value.status)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_list(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 

--- a/test/api/test_project.py
+++ b/test/api/test_project.py
@@ -10,7 +10,7 @@ class TestApiDomain(api_test.ApiTestCase):
         self.url_base = 'https://cloud1.memsource.com/web/api/v3/project'
         self.project = api.Project(None)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
         returning_id = self.gen_random_int()
@@ -44,7 +44,7 @@ class TestApiDomain(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_list(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -85,7 +85,7 @@ class TestApiDomain(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_get_trans_memories(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
         project_id = self.gen_random_int()
@@ -122,7 +122,7 @@ class TestApiDomain(api_test.ApiTestCase):
         for translation_memory in returned_values:
             self.assertIsInstance(translation_memory, models.TranslationMemory)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_set_trans_memories(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 

--- a/test/api/test_translation_memory.py
+++ b/test/api/test_translation_memory.py
@@ -15,7 +15,7 @@ class TestApiTranslationMemory(api_test.ApiTestCase):
         with open(self.test_tmx_file_path, 'w+') as f:
             f.write('This is test tmx file.')
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_create(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
         returning_id = self.gen_random_int()
@@ -41,7 +41,7 @@ class TestApiTranslationMemory(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_list(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
         mock_request().json.return_value = [{
@@ -66,7 +66,7 @@ class TestApiTranslationMemory(api_test.ApiTestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_upload(self, mock_request):
         accepted_segments_count = self.gen_random_int()
         type(mock_request()).status_code = PropertyMock(return_value=200)
@@ -95,7 +95,7 @@ class TestApiTranslationMemory(api_test.ApiTestCase):
 
         self.assertEqual(accepted_segments_count, returned_value)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_upload_from_text(self, mock_request):
         accepted_segments_count = self.gen_random_int()
         type(mock_request()).status_code = PropertyMock(return_value=200)
@@ -123,7 +123,7 @@ class TestApiTranslationMemory(api_test.ApiTestCase):
 
         self.assertEqual(accepted_segments_count, returned_value)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_search_segment_by_task(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -219,7 +219,7 @@ class TestApiTranslationMemory(api_test.ApiTestCase):
         for segment_search_result in returned_value:
             self.assertIsInstance(segment_search_result, models.SegmentSearchResult)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_insert(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 

--- a/test/test_memsource.py
+++ b/test/test_memsource.py
@@ -13,7 +13,7 @@ class TestMemsource(unittest.TestCase):
         for api in ('client', 'domain', 'project', 'job', ):
             self.assertEqual(getattr(m, api).token, token)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_init_with_user_name_and_password(self, mock_request):
         type(mock_request()).status_code = PropertyMock(return_value=200)
 
@@ -39,7 +39,7 @@ class TestMemsource(unittest.TestCase):
             timeout=constants.Base.timeout.value
         )
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_init_with_token(self, mock_request):
         token = 'test_token'
         self.check_token(Memsource(token=token), token)
@@ -47,7 +47,7 @@ class TestMemsource(unittest.TestCase):
         # When token is given as parameter, never send http request.
         self.assertFalse(mock_request.called)
 
-    @patch.object(requests, 'request')
+    @patch.object(requests.Session, 'request')
     def test_init_with_user_name_and_password_and_token(self, mock_request):
         token = 'test_token'
         m = Memsource(user_name='test user name', password='test password', token=token)


### PR DESCRIPTION
For example, you can specify maximum number of TCP connections in the connection pool.