### PR TITLE
[#114702249] Use Job API v7

### DIFF
--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 __license__ = 'MIT'

--- a/memsource/api.py
+++ b/memsource/api.py
@@ -315,9 +315,9 @@ class Project(BaseApi):
 
 class Job(BaseApi):
     """
-    You can see the document http://wiki.memsource.com/wiki/Job_API_v6
+    You can see the document http://wiki.memsource.com/wiki/Job_API_v7
     """
-    api_version = constants.ApiVersion.v6
+    api_version = constants.ApiVersion.v7
 
     def create(self, project_id: int, file_path: str, target_langs):
         """

--- a/memsource/constants.py
+++ b/memsource/constants.py
@@ -10,7 +10,7 @@ class ApiVersion(enum.Enum):
     v2 = 'v2'
     v3 = 'v3'
     v4 = 'v4'
-    v6 = 'v6'
+    v7 = 'v7'
 
 
 class HttpMethod(enum.Enum):

--- a/memsource/models.py
+++ b/memsource/models.py
@@ -68,7 +68,7 @@ class Segment(BaseModel):
 class SegmentSearchResult(BaseModel):
     """
     Sometime segment has more data. It is for it. Give me a good name for this class.
-    http://wiki.memsource.com/wiki/Job_API_v6#Get_Segments is for Segment.
+    http://wiki.memsource.com/wiki/Job_API_v7#Get_Segments is for Segment.
     http://wiki.memsource.com/wiki/Translation_Memory_API_v4#Search_Segment_By_Task is for this.
     """
     pass

--- a/test/api/test_job.py
+++ b/test/api/test_job.py
@@ -9,7 +9,7 @@ import api as api_test
 
 class TestApiJob(api_test.ApiTestCase):
     def setUp(self):
-        self.url_base = 'https://cloud.memsource.com/web/api/v6/job'
+        self.url_base = 'https://cloud.memsource.com/web/api/v7/job'
         self.job = api.Job(None)
         self.test_file_path = '/tmp/test_file.txt'
         self.test_file_uuid1_name = 'test-file-uuid1'
@@ -254,7 +254,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
-            'https://cloud.memsource.com/web/api/v6/job/getBilingualFile',
+            'https://cloud.memsource.com/web/api/v7/job/getBilingualFile',
             params={
                 'token': self.job.token,
                 'jobPart': job_part_ids,
@@ -281,7 +281,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
-            'https://cloud.memsource.com/web/api/v6/job/getBilingualFile',
+            'https://cloud.memsource.com/web/api/v7/job/getBilingualFile',
             params={
                 'token': self.job.token,
                 'jobPart': job_part_ids,
@@ -334,7 +334,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
-            'https://cloud.memsource.com/web/api/v6/job/getBilingualFile',
+            'https://cloud.memsource.com/web/api/v7/job/getBilingualFile',
             params={
                 'token': self.job.token,
                 'jobPart': job_part_ids,
@@ -377,7 +377,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
-            'https://cloud.memsource.com/web/api/v6/job/getSegments',
+            'https://cloud.memsource.com/web/api/v7/job/getSegments',
             params={
                 'token': self.job.token,
                 'task': task,
@@ -405,7 +405,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
-            'https://cloud.memsource.com/web/api/v6/job/uploadBilingualFile',
+            'https://cloud.memsource.com/web/api/v7/job/uploadBilingualFile',
             params={
                 'token': self.job.token,
             },
@@ -427,7 +427,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
-            'https://cloud.memsource.com/web/api/v6/job/getCompletedFile',
+            'https://cloud.memsource.com/web/api/v7/job/getCompletedFile',
             params={
                 'token': self.job.token,
                 'jobPart': job_part_ids,

--- a/test/api/test_job.py
+++ b/test/api/test_job.py
@@ -9,7 +9,8 @@ import api as api_test
 
 class TestApiJob(api_test.ApiTestCase):
     def setUp(self):
-        self.url_base = 'https://cloud.memsource.com/web/api/v7/job'
+        self.url_base = "https://cloud.memsource.com/web/api/{}/job".format(
+            api.Job.api_version.value)
         self.job = api.Job(None)
         self.test_file_path = '/tmp/test_file.txt'
         self.test_file_uuid1_name = 'test-file-uuid1'
@@ -254,7 +255,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
-            'https://cloud.memsource.com/web/api/v7/job/getBilingualFile',
+            "{}/getBilingualFile".format(self.url_base),
             params={
                 'token': self.job.token,
                 'jobPart': job_part_ids,
@@ -281,7 +282,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
-            'https://cloud.memsource.com/web/api/v7/job/getBilingualFile',
+            "{}/getBilingualFile".format(self.url_base),
             params={
                 'token': self.job.token,
                 'jobPart': job_part_ids,
@@ -334,7 +335,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
-            'https://cloud.memsource.com/web/api/v7/job/getBilingualFile',
+            "{}/getBilingualFile".format(self.url_base),
             params={
                 'token': self.job.token,
                 'jobPart': job_part_ids,
@@ -377,7 +378,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
-            'https://cloud.memsource.com/web/api/v7/job/getSegments',
+            "{}/getSegments".format(self.url_base),
             params={
                 'token': self.job.token,
                 'task': task,
@@ -405,7 +406,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
-            'https://cloud.memsource.com/web/api/v7/job/uploadBilingualFile',
+            "{}/uploadBilingualFile".format(self.url_base),
             params={
                 'token': self.job.token,
             },
@@ -427,7 +428,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
-            'https://cloud.memsource.com/web/api/v7/job/getCompletedFile',
+            "{}/getCompletedFile".format(self.url_base),
             params={
                 'token': self.job.token,
                 'jobPart': job_part_ids,


### PR DESCRIPTION
This library is using v6. However v7 is released.