### PR TITLE
[#119966769] Support delete segments for translation memory

### DIFF
--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.0.9'
+__version__ = '0.1.0'
 __license__ = 'MIT'

--- a/memsource/api.py
+++ b/memsource/api.py
@@ -6,6 +6,8 @@ import types
 import typing
 import uuid
 
+from typing import List
+
 import requests
 
 from memsource import constants, exceptions, models
@@ -587,6 +589,21 @@ class TranslationMemory(BaseApi):
             params['nextSourceSegment'] = next_source_segment
 
         self._post('transMemory/insert', params)
+
+    def deleteSourceAndTranslations(
+            self, translation_memory_id: int, segment_ids: List[str]) -> None:
+        """Delete segments from a translation memory.
+
+        :param translation_memory_id: Delete the segments from this translation
+        memory.
+        :param segment_ids: Delete these segments from the translation memory.
+        You cannot pass more than 1000 ids one time.
+        """
+        assert 1000 > len(segment_ids), "You cannot pass more than 1000 ids one time."
+        self._post('transMemory/deleteSourceAndTranslations', {
+            'transMemory': translation_memory_id,
+            'segmentId': segment_ids
+        })
 
 
 class Asynchronous(BaseApi):

--- a/test/api/test_translation_memory.py
+++ b/test/api/test_translation_memory.py
@@ -1,7 +1,10 @@
 from unittest.mock import patch, PropertyMock
-from memsource import api, constants, models
+import urllib.request
+
 import requests
+
 import api as api_test
+from memsource import api, constants, models
 
 
 class TestApiTranslationMemory(api_test.ApiTestCase):
@@ -250,6 +253,26 @@ class TestApiTranslationMemory(api_test.ApiTestCase):
                 'targetSegment': target_segment,
                 'previousSourceSegment': previous_source_segment,
                 'nextSourceSegment': next_source_segment
+            },
+            files={},
+            timeout=constants.Base.timeout.value
+        )
+
+    @patch.object(requests.Session, 'request')
+    def test_delete_source_and_translations(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+        translation_memory_id = 1
+        segment_ids = ['2', '3']
+
+        self.translation_memory.deleteSourceAndTranslations(translation_memory_id, segment_ids)
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.post.value,
+            urllib.request.urljoin(self.url_base, "transMemory/deleteSourceAndTranslations"),
+            params={
+                'token': self.translation_memory.token,
+                'transMemory': translation_memory_id,
+                'segmentId': segment_ids
             },
             files={},
             timeout=constants.Base.timeout.value


### PR DESCRIPTION
It is "Delete Source And Translation" in http://wiki.memsource.com/wiki/Translation_Memory_API_v4