### PR TITLE
Add changelog file and bump version 0.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,12 @@
+==========
+Change Log
+==========
+All notable changes to this project will be documented in this file. Dates are in UTC.
+
+[0.3.0] - 2016-07-05
+====================
+
+Added
+-----
+
+- Support page argument for list of translation memory api.

--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 __license__ = 'MIT'


### PR DESCRIPTION
Because https://github.com/gengo/memsource-wrap/pull/50 added new functionalty.