### PR TITLE
Cancel fixed external libraries version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Change Log
 ==========
 All notable changes to this project will be documented in this file. Dates are in UTC.
 
+Unreleased
+==========
+
+Fixed
+=====
+
+- Cancel fixed external libraries version.
+
 [0.3.0] - 2016-07-05
 ====================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-requests==2.7.0
+requests>=2.7.0
 # Memsource API returns datetime as iso8601
-iso8601==0.1.10
-nose==1.3.7
-coverage==3.7.1
-rednose==0.4.3
-flake8==2.2.5
-inflection==0.3.1
-lxml==3.4.4
-mypy-lang==0.2.0
+iso8601>=0.1.10
+nose>=1.3.7
+coverage>=3.7.1
+rednose>=0.4.3
+flake8>=2.2.5
+inflection>=0.3.1
+lxml>=3.4.4
+mypy-lang>=0.2.0


### PR DESCRIPTION
Actually, memsource-wrap isn't depending on certain external libraries. Fixed
external libraries version introduces version conflict problem easily. For
example, this library required requests version 2.7.0. If another library wants
to use latest(2.10.0) requests functionality, they must conflict.