### PR TITLE
[#153921933] Enclose memsource search query string in double quotes to avoid wildcard searching

### DIFF
--- a/memsource/api.py
+++ b/memsource/api.py
@@ -686,7 +686,7 @@ class TranslationMemory(BaseApi):
         """
         parameters = dict(
             kwargs, transMemory=translation_memory_id,
-            query=query, sourceLang=source_lang)
+            query='"{}"'.format(query), sourceLang=source_lang)
 
         if target_langs is not None:
             parameters['targetLang'] = target_langs

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ flake8>=2.2.5
 inflection>=0.3.1
 lxml>=3.4.4
 mypy-lang>=0.2.0
+typing>=3.6.2

--- a/test/api/test_translation_memory.py
+++ b/test/api/test_translation_memory.py
@@ -263,7 +263,7 @@ class TestApiTranslationMemory(api_test.ApiTestCase):
             data={
                 'token': self.translation_memory.token,
                 'transMemory': translation_memory_id,
-                'query': query,
+                'query': '"{}"'.format(query),
                 'sourceLang': source_lang,
                 'targetLang': target_langs,
                 'nextSegment': next_segment,


### PR DESCRIPTION
## Description
- '?' is considered as a wildcard character in tm search request
- Enclose memsource search query string in double quotes to avoid wildcard searching

## Story
https://www.pivotaltracker.com/story/show/153921933

  
  