### PR TITLE
[#155024178] query export download URL creation function

### DIFF
--- a/memsource/api.py
+++ b/memsource/api.py
@@ -886,28 +886,51 @@ class Asynchronous(BaseApi):
         )
 
     def exportByQuery(
-            self, tm_id: int, query: str, target_langs: Union[str, List[str]], *, file_format=None,
-            callback_url=None, **kwargs: dict) -> models.AsynchronousResponse:
+            self, tm_id: int, query: str, target_langs: Union[str, List[str]], *,
+            callback_url=None, **kwargs: dict) -> models.AsynchronousRequest:
         """Create a translation memory data export asynchronously.
 
         :param tm_id: ID of the translation memory.
         :param query: Text/pattern you are searching for. See Memsource documentation.
         :param target_langs: The target languages you would like exported.
-        :param file_format: TMX or XLSX. Memsource currently defaults to TMX.
         :param callback_url: Memsource will hit this url when finished to create the job.
         :param kwargs: See Memsource documentation
         https://wiki.memsource.com/wiki/Translation_Memory_Asynchronous_API_v2
 
-        :return: models.AsynchronousResponse
+        :return: models.AsynchronousRequest
         """
         return models.AsynchronousRequest(self._get('transMemory/exportByQuery', dict(kwargs, **{
                 'transMemory': tm_id,
                 'exportTargetLang': target_langs,
                 'query': query,
                 'queryLang': target_langs,
-                'format': file_format,
                 'callbackUrl': callback_url,
             }))['asyncRequest'])
+
+    def make_download_url(self, async_request_id: int, *, file_format: str=None) -> str:
+        """Returns the download link of a previously-requested TM export.
+
+        :param async_request_id: ID of the Memsource asynchronous request.
+        :param file_format: TMX or XLSX. Default to TMX if unspecified.
+
+        :return: URL string
+        """
+        url = self._make_url(
+            base=constants.Base.url.value,
+            api_version=self.api_version.value,
+            path='transMemory/downloadExport',
+        )
+
+        params = {
+            'token': self.token,
+            'asyncRequest': async_request_id,
+        }
+        if file_format:
+            params['format'] = file_format
+
+        params_string = '&'.join(['{}={}'.format(key, value) for key, value in params.items()])
+
+        return '{url}?{params}'.format(url=url, params=params_string)
 
 
 class Analysis(BaseApi):

--- a/memsource/api.py
+++ b/memsource/api.py
@@ -3,6 +3,7 @@ import os
 import os.path
 import shutil
 import types
+import urllib.parse
 import uuid
 
 from typing import (
@@ -928,7 +929,7 @@ class Asynchronous(BaseApi):
         if file_format:
             params['format'] = file_format
 
-        params_string = '&'.join(['{}={}'.format(key, value) for key, value in params.items()])
+        params_string = urllib.parse.urlencode(params)
 
         return '{url}?{params}'.format(url=url, params=params_string)
 

--- a/test/api/test_asynchronous.py
+++ b/test/api/test_asynchronous.py
@@ -402,7 +402,6 @@ class TestApiAsynchronous(api_test.ApiTestCase):
         tm_id = self.gen_random_int()
         langs = 'en'
         query = '*'
-        file_format = 'TMX'
         callback_url = 'CALLBACK_URL'
 
         mock_request().json.return_value = {
@@ -427,7 +426,6 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             tm_id=tm_id,
             query=query,
             target_langs=langs,
-            file_format=file_format,
             callback_url=callback_url
         )
 
@@ -442,7 +440,45 @@ class TestApiAsynchronous(api_test.ApiTestCase):
                 'exportTargetLang': langs,
                 'query': query,
                 'queryLang': langs,
-                'format': file_format,
                 'callbackUrl': callback_url,
             },
             timeout=constants.Base.timeout.value)
+
+    def test_make_download_url(self):
+        fake_async_request_id = 5
+        file_format = 'XLSX'
+
+        base_dl_url = '{}/async/v2/transMemory/downloadExport'.format(constants.Base.url.value)
+
+        tests = [
+            (
+                {
+                    'async_request_id': fake_async_request_id
+                },
+                'token={}&asyncRequest={}'.format(
+                    self.asynchronous.token,
+                    fake_async_request_id,
+                )
+            ),
+            (
+                {
+                    'async_request_id': fake_async_request_id,
+                    'file_format': file_format,
+                },
+                'token={}&asyncRequest={}&format={}'.format(
+                    self.asynchronous.token,
+                    fake_async_request_id,
+                    file_format,
+                )
+            ),
+        ]
+
+        for method_kwargs, expected_params in tests:
+            download_url = self.asynchronous.make_download_url(**method_kwargs)
+            self.assertEqual(
+                download_url,
+                '{}?{}'.format(
+                    base_dl_url,
+                    expected_params,
+                )
+            )

--- a/test/api/test_asynchronous.py
+++ b/test/api/test_asynchronous.py
@@ -462,8 +462,8 @@ class TestApiAsynchronous(api_test.ApiTestCase):
             ),
             (
                 {
-                    'async_request_id': fake_async_request_id,
                     'file_format': file_format,
+                    'async_request_id': fake_async_request_id,
                 },
                 'token={}&asyncRequest={}&format={}'.format(
                     self.asynchronous.token,


### PR DESCRIPTION
- the new `make_download_url` function will return a URL allowing to download a TM export query request asynchronously (via `exportByQuery`). This uses the existing `transMemory/downloadExport` endpoint (https://wiki.memsource.com/wiki/Translation_Memory_Asynchronous_API_v2)

- removed the `format` (aka file format) option from the `exportByQuery` function since it is not actually one of its parameters but is instead passed to the download endpoint. Memsource was not throwing an error as it does not seem to mind extra parameters.