### PR TITLE
[#155317028] download TM export requested asynchronously

### DIFF
--- a/memsource/api.py
+++ b/memsource/api.py
@@ -922,6 +922,24 @@ class Asynchronous(BaseApi):
                 'callbackUrl': callback_url,
             }))['asyncRequest'])
 
+    def downloadExport(self, async_request_id: int, file_path: str, *, file_format: str='TMX',
+                       chunk_size: int=1024) -> None:
+        """Download the completed export of a translation memory.
+
+        :param async_request_id: ID of the export request - e.g. requested via exportByQuery()
+        :param file_format: TMX or XLSX. Defaults to TMX.
+        :param file_path: Save exported data to this file path.
+        :param chunk_size: byte size of chunk for response data.
+        """
+        params = {
+            'asyncRequest': async_request_id,
+            'format': file_format,
+        }
+
+        with open(file_path, 'wb') as f:
+            [f.write(chunk) for chunk in
+                self._get_stream('transMemory/downloadExport', params).iter_content(chunk_size)]
+
     def make_download_url(self, async_request_id: int, *, file_format: str=None) -> str:
         """Returns the download link of a previously-requested TM export.
 


### PR DESCRIPTION
This is a rehash of the existing synchronous function but using a different endpoint and different params because it downloads an export created by Memsource on their side.

Doc: https://wiki.memsource.com/wiki/Translation_Memory_Asynchronous_API_v2

Existing synchronous version: https://github.com/gengo/memsource-wrap/blob/master/memsource/api.py#L720-L737

Tested on local machine and works like a charm 👌 
Not sure if it's worth writing unit tests for this and not sure how to proceed... Synchronous function doesn't have any.