### PR TITLE
Support project set status API

### DIFF
--- a/memsource/api.py
+++ b/memsource/api.py
@@ -360,6 +360,20 @@ class Project(BaseApi):
         # This end-point return nothing.
         self._post('project/setTransMemories', params)
 
+    def setStatus(self, project_id: int, status: constants.ProjectStatus) -> None:
+        """Update project status
+
+        ProjectStatus: New, Emailed, Assigned, Declined_By_Linguist,
+                       Completed_By_Linguist, Completed, Cancelled
+
+        :param project_id: id of project you want to update.
+        :param status: status of project to update. Acceptable type is ProjectStatus constant.
+        """
+        self._post('project/setStatus', {
+            'project': project_id,
+            'status': status.value
+        })
+
 
 class Job(BaseApi):
     """You can see the document http://wiki.memsource.com/wiki/Job_API_v7
@@ -576,7 +590,7 @@ class Job(BaseApi):
             'purge': purge
         })
 
-    def setStatus(self, job_part_id: int, status: str) -> None:
+    def setStatus(self, job_part_id: int, status: constants.JobStatus) -> None:
         """Update job status
 
         JobStatus: New, Emailed, Assigned, Declined_By_Linguist,
@@ -587,7 +601,7 @@ class Job(BaseApi):
         """
         self._post('job/setStatus', {
             'jobPart': job_part_id,
-            'status': status
+            'status': status.value
         })
 
 

--- a/memsource/constants.py
+++ b/memsource/constants.py
@@ -16,6 +16,16 @@ class JobStatus(enum.Enum):
     CANCELLED = "Cancelled"
 
 
+class ProjectStatus(enum.Enum):
+    NEW = "New"
+    ASSIGNED = "Assigned"
+    COMPLETED = "Completed"
+    CANCELLED = "Cancelled"
+    ACCEPTED_BY_VENDOR = "Accepted_By_Vendor"
+    DECLINED_BY_VENDOR = "Declined_By_Vendor"
+    COMPLETED_BY_VENDOR = "Completed_By_Vendor"
+
+
 class ApiVersion(enum.Enum):
     v2 = 'v2'
     v3 = 'v3'

--- a/test/api/test_job.py
+++ b/test/api/test_job.py
@@ -506,7 +506,7 @@ class TestApiJob(api_test.ApiTestCase):
 
         job_part_id = self.gen_random_int()
 
-        self.assertIsNone(self.job.setStatus(job_part_id, constants.JobStatus.COMPLETED.value))
+        self.assertIsNone(self.job.setStatus(job_part_id, constants.JobStatus.COMPLETED))
 
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,

--- a/test/api/test_job.py
+++ b/test/api/test_job.py
@@ -514,7 +514,7 @@ class TestApiJob(api_test.ApiTestCase):
             data={
                 'token': self.job.token,
                 'jobPart': job_part_id,
-                'status': "Completed",
+                'status': constants.JobStatus.COMPLETED.value,
             },
             timeout=constants.Base.timeout.value
         )

--- a/test/api/test_project.py
+++ b/test/api/test_project.py
@@ -177,7 +177,7 @@ class TestApiProject(api_test.ApiTestCase):
             data={
                 'token': self.project.token,
                 'project': project_id,
-                'status': "Cancelled",
+                'status': constants.ProjectStatus.CANCELLED.value,
             },
             timeout=constants.Base.timeout.value
         )

--- a/test/api/test_project.py
+++ b/test/api/test_project.py
@@ -161,3 +161,23 @@ class TestApiProject(api_test.ApiTestCase):
             },
             timeout=constants.Base.timeout.value
         )
+
+    @patch.object(requests.Session, 'request')
+    def test_setStatus(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+        mock_request().json.return_value = None
+
+        project_id = self.gen_random_int()
+
+        self.assertIsNone(self.project.setStatus(project_id, constants.ProjectStatus.CANCELLED))
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.post.value,
+            '{}/setStatus'.format(self.url_base),
+            data={
+                'token': self.project.token,
+                'project': project_id,
+                'status': "Cancelled",
+            },
+            timeout=constants.Base.timeout.value
+        )


### PR DESCRIPTION
## Description
- Change parameter for job. instead of string converted to enum(JobStatus)
```diff
- job.setStatus(job_id, ms_constants.JobStatus.COMPLETED.value)
+ job.setStatus(job_id, ms_constants.JobStatus.COMPLETED)
```

- Support `setStatus` endpoint for project on memsource
https://wiki.memsource.com/wiki/Project_API_v3#Set_Status
