### PR TITLE
Fix use of constant enum in term base download

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file. Dates are i
 Unreleased
 ==========
 
+[0.4.5] - 2018-10-29
+====================
+
+Fix
+-----
+- Fix file format parameter constant in term base download method.
+
 [0.4.4] - 2018-10-25
 ====================
 

--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.4.4'
+__version__ = '0.4.5'
 __license__ = 'MIT'

--- a/memsource/api.py
+++ b/memsource/api.py
@@ -207,7 +207,7 @@ class BaseApi:
         return self._get_response(http_method, url, timeout=timeout, **arguments).json()
 
     @staticmethod
-    def is_success(status_code: {int}):
+    def is_success(status_code: int):
         # if status_code is float type, we will get unexpected result.
         # but I think it is not big deal.
         return 200 <= status_code < 300
@@ -1079,7 +1079,7 @@ class TermBase(BaseApi):
     api_version = constants.ApiVersion.v2
 
     def download(self, termbase_id: int, filepath: str, *,
-                 file_format: str=constants.TermBaseFormat.XLSX,
+                 file_format: constants.TermBaseFormat=constants.TermBaseFormat.XLSX,
                  chunk_size: int=1024) -> None:
         """Download a term base.
 
@@ -1090,7 +1090,7 @@ class TermBase(BaseApi):
         """
         params = {
             'termBase': termbase_id,
-            'format': file_format,
+            'format': file_format.value,
         }
 
         with open(filepath, 'wb') as f:

--- a/test/api/test_term_base.py
+++ b/test/api/test_term_base.py
@@ -42,7 +42,7 @@ class TestApiTermBase(api_test.ApiTestCase):
             params={
                 'token': self.termbase.token,
                 'termBase': 123,
-                'format': constants.TermBaseFormat.XLSX,
+                'format': 'XLSX',
             },
             timeout=constants.Base.timeout.value * 5,
             stream=True,


### PR DESCRIPTION
- Fix erroneous use of constant enum; lesson learned - it's sometimes better to hardcode values in tests!
- Fix old `{int}` typing that broke mypy analysis

🙇 