### PR TITLE
Upgrade python 3.4 to python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4"
+  - "3.5"
 
 sudo: false
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file. Dates are i
 Unreleased
 ==========
 
+[0.4.7] - 2019-08-19
+====================
+
+Upgraded
+-----
+- Upgraded python version from python3.4 to python3.5.
+
 [0.4.6] - 2018-11-08
 ====================
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ memsource-wrap
 ##############
 Memsource API Wrap Library for Python
 
-This library require Python 3.4. If Python 3.4 is not installed on your system, I recommened to use `Pythonz <https://github.com/saghul/pythonz>`_
+This library require Python 3.5. If Python 3.5 is not installed on your system, I recommened to use `Pythonz <https://github.com/saghul/pythonz>`_
 
 Install
 =======

--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.4.6'
+__version__ = '0.4.7'
 __license__ = 'MIT'


### PR DESCRIPTION
lxml requires Python 2.7, 3.5 or later
```
collecting lxml>=3.4.4 (from -r requirements.txt (line 9))
  Downloading https://files.pythonhosted.org/packages/e1/f5/5eb3b491958dcfdcfa5daae3c655ab59276bc216ca015e44743c9c220e9e/lxml-4.4.0.tar.gz (4.5MB)
     |████████████████████████████████| 4.5MB 229kB/s
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: This lxml version requires Python 2.7, 3.5 or later.
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-2ajashgz/lxml/
```
So I found this issue as an opportunity to upgrade the python version from python3.4 to python3.5.