### PR TITLE
Fix bug in Auth class when getting token

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file. Dates are i
 Unreleased
 ==========
 
+[0.5.0] - 2019-11-28
+====================
+
+Fix bug
+-----
+- Fix bug in getting token in Memsource Auth class.
+
 [0.4.9] - 2019-08-23
 ====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. Dates are i
 Unreleased
 ==========
 
-[0.5.0] - 2019-11-28
+[0.4.10] - 2019-11-28
 ====================
 
 Fix bug

--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.4.9'
+__version__ = '0.5.0'
 __license__ = 'MIT'

--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.5.0'
+__version__ = '0.4.10'
 __license__ = 'MIT'

--- a/memsource/memsource.py
+++ b/memsource/memsource.py
@@ -8,7 +8,7 @@ class Memsource(object):
         Otherwise authenticate with user_name and password, and get token.
         """
         if user_name and password and not token and not headers:
-            token = api.Auth(token, headers).login(user_name, password).token
+            token = api.Auth().login(user_name, password).token
 
         # make api class instances
         self.auth = api.Auth(token, headers)

--- a/memsource/memsource.py
+++ b/memsource/memsource.py
@@ -7,11 +7,11 @@ class Memsource(object):
         If token is given, use the token.
         Otherwise authenticate with user_name and password, and get token.
         """
-        self.auth = api.Auth(token, headers)
         if user_name and password and not token and not headers:
-            token = self.auth.login(user_name, password).token
+            token = api.Auth(token, headers).login(user_name, password).token
 
         # make api class instances
+        self.auth = api.Auth(token, headers)
         self.client = api.Client(token, headers)
         self.domain = api.Domain(token, headers)
         self.project = api.Project(token, headers)

--- a/test/test_memsource.py
+++ b/test/test_memsource.py
@@ -1,6 +1,6 @@
 import unittest
 import requests
-from memsource import constants
+from memsource import api, constants
 from memsource.memsource import Memsource
 from unittest.mock import patch, PropertyMock
 
@@ -10,9 +10,13 @@ class TestMemsource(unittest.TestCase):
         self.url_base = 'https://cloud.memsource.com/web/api/v3/auth/login'
 
     def check_token_and_headers(self, m, token=None, headers=None):
-        for api in ('client', 'domain', 'project', 'job', ):
-            self.assertEqual(getattr(m, api).token, token)
-            self.assertEqual(getattr(m, api).headers, headers)
+        class_names = [
+            'auth', 'client', 'domain', 'project', 'job', 'translation_memory',
+            'asynchronous', 'language', 'analysis', 'term_base'
+        ]
+        for name in class_names:
+            self.assertEqual(getattr(m, name).token, token)
+            self.assertEqual(getattr(m, name).headers, headers)
 
     @patch.object(requests.Session, 'request')
     def test_init_with_user_name_and_password(self, mock_request):
@@ -56,16 +60,24 @@ class TestMemsource(unittest.TestCase):
         # When token is given as parameter, never send http request.
         self.assertFalse(mock_request.called)
 
-    @patch.object(requests.Session, 'request')
-    def test_header_memsource_parameter(self, mock_request):
-        mock_request.return_value.status_code = 200
+    @patch.object(api.Auth, 'login')
+    def test_init_with_header_with_user_name_password(self, mock_login):
         token = None
-        mock_request().json.return_value = {
-            'token': token,
-            'user': {},
-        }
+        username = 'test_username'
+        password = 'test_password'
         headers = {
             'Authorization': 'Bearer test_token'
         }
-        self.check_token_and_headers(Memsource(headers=headers), token, headers)
-        mock_request.called
+
+        self.check_token_and_headers(
+            Memsource(
+                user_name=username,
+                password=password,
+                headers=headers,
+            ),
+            token,
+            headers
+        )
+
+        # When header is given, should not call login method.
+        self.assertFalse(mock_login.called)


### PR DESCRIPTION
- Getting token in `Auth` class is always `None`.
- Passed the token in `Auth` class so that it will have a token value.
- Added some test scenarios.
