### PR TITLE
REST job class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file. Dates are i
 
 Unreleased
 ==========
+[0.5.4] - 2020-06-24
+====================
+
+Added
+-----
+- Added a new Job class for Memsource REST transition.
+
 [0.5.3] - 2020-06-23
 ====================
 

--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 __license__ = 'MIT'

--- a/memsource/api_rest/__init__.py
+++ b/memsource/api_rest/__init__.py
@@ -132,6 +132,37 @@ class BaseApi:
             timeout=timeout
         ).json()
 
+    def _delete(
+            self,
+            path: str,
+            params: Dict[str, Any]={},
+            data: Optional[Dict[str, Any]]=None,
+            timeout: Union[int, float]=constants.BaseRest.timeout.value,
+    ) -> Dict[str, Any]:
+        """Send a delete request.
+
+        :param path: Send request to this path
+        :param params: Send request with this query parameters
+        :param data: Send request with this body parameters
+        :param timeout: When takes over this time in one request, raise timeout
+        :return: parsed response body as JSON
+        """
+        resp = self._request(
+            http_method=constants.HttpMethod.delete,
+            path=path,
+            files=None,
+            params=params,
+            data=data,
+            timeout=timeout
+        )
+        resp.raise_for_status()
+
+        # Some resources return 204 were there is no response body.
+        # https://cloud.memsource.com/web/docs/api#operation/deleteParts
+        if resp.status_code == HTTPStatus.NO_CONTENT:
+            return {}
+        return resp.json()
+
     def _pre_request(self, path: str, params: Dict[str, Any]) -> Tuple[str,  Dict[str, Any]]:
         """Create request url and extend param with token for authentication.
 

--- a/memsource/api_rest/job.py
+++ b/memsource/api_rest/job.py
@@ -1,0 +1,244 @@
+import io
+import json
+import os
+import types
+import uuid
+from typing import Any, Dict, List
+
+from memsource import api_rest, constants, exceptions, models
+
+
+class Job(api_rest.BaseApi):
+    # Document: https://cloud.memsource.com/web/docs/api#tag/Job
+    def _create(
+            self,
+            project_id: int,
+            target_langs: List[str],
+            files: Dict[str, Any]
+    ) -> List[models.JobPart]:
+        """Common process of creating job.
+
+        If returning JSON has `unsupportedFiles`,
+        this method raise MemsourceUnsupportedFileException
+
+        :param project_id: New job will be in this project.
+        :param file_path: Source file of job.
+        :param target_langs: List of translation target languages.
+        :return: List of models.JobPart
+        """
+
+        if isinstance(files["file"], tuple):
+            # If value is tuple type, this function called from createFromText.
+            # We need to create temporary file for to raise exception.
+            file_name, text = files["file"]
+            file_path = os.path.join("/", "tmp", file_name)
+        else:
+            file_name = file_path = files["file"].name
+
+        job_create_extra_headers = {
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": "inline; filename=\"{}\"".format(file_name),
+            "Memsource": json.dumps({"targetLangs": target_langs})
+        }
+        if self.headers is None:
+            self.headers = job_create_extra_headers
+        else:
+            self.headers.update(job_create_extra_headers)
+
+        result = self._post("v1/projects/{}/jobs".format(project_id), {
+            "targetLangs": target_langs,
+        }, files)
+
+        # unsupported file count is 0 mean success.
+        unsupported_files = result.get("unsupportedFiles", [])
+        if len(unsupported_files) == 0:
+            return [models.JobPart(job_parts) for job_parts in result["jobs"]]
+
+        if isinstance(files["file"], tuple):
+            with open(file_path, "w+") as f:
+                f.write(text)
+
+        raise exceptions.MemsourceUnsupportedFileException(
+            unsupported_files,
+            file_path,
+            self.last_url,
+            self.last_params
+        )
+
+    def create(
+            self, project_id: int, file_path: str, target_langs: List[str]
+    ) -> List[models.JobPart]:
+        """Create a job.
+
+        If returning JSON has `unsupportedFiles`,
+        this method raise MemsourceUnsupportedFileException
+
+        :param project_id: New job will be in this project.
+        :param file_path: Source file of job.
+        :param target_langs: List of translation target languages.
+        :return: List of models.JobPart
+        """
+        with open(file_path, 'r') as f:
+            return self._create(project_id, target_langs, {'file': f})
+
+    def create_from_text(
+            self,
+            project_id: int,
+            text: str,
+            target_langs: List[str],
+            file_name: str=None,
+    ) -> List[models.JobPart]:
+        """You can create a job without a file.
+
+        See: Job.create
+        If returning JSON has `unsupportedFiles`,
+        this method raise MemsourceUnsupportedFileException
+
+        :param project_id: New job will be in this project.
+        :param text: Source text of job.
+        :param target_langs: List of translation target languages.
+        :param file_name: Create file name by uuid1() when file_name parameter is None.
+        :return: List of models.JobPart
+        """
+        return self._create(project_id, target_langs, {
+            'file': ('{}.txt'.format(uuid.uuid1().hex) if file_name is None else file_name, text),
+        })
+
+    def list_by_project(
+            self,
+            project_id: int,
+            page: int = 0,
+    ) -> List[models.JobPart]:
+        jobs = self._get("v2/projects/{}/jobs".format(project_id), {"page": page})
+        return [models.JobPart(job_part) for job_part in jobs["content"]]
+
+    def pre_translate(
+            self,
+            project_id: int,
+            job_parts: List[Dict[str, str]],
+            translation_memory_threshold: float=0.7,
+            callback_url: str=None,
+    ) -> models.AsynchronousRequest:
+        """Call async pre translate API.
+
+        :param job_parts: Dictionary of job_part id with format `{"uid": string}`.
+        :param translation_memory_threshold: If matching score is higher than this, it is filled.
+        :return: models.AsynchronousRequest
+        """
+        response = self._post("v1/projects/{}/jobs/preTranslate".format(project_id), {
+            "jobs": [{"uid": job_part} for job_part in job_parts],
+            "translationMemoryTreshold": translation_memory_threshold,
+            "callbackUrl": callback_url,
+        })
+
+        return models.AsynchronousRequest(response["asyncRequest"])
+
+    def get_completed_file_text(self, project_id: int, job_uid: str) -> bytes:
+        """Download completed file and return it.
+
+        :param job_uid: job UID.
+        """
+        def get_completed_file_stream() -> types.GeneratorType:
+            return self._get_stream(
+                "v1/projects/{}/jobs/{}/targetFile".format(project_id, job_uid)
+            ).iter_content(constants.CHUNK_SIZE)
+
+        buffer = io.BytesIO()
+        [buffer.write(chunk) for chunk in get_completed_file_stream()]
+
+        return buffer.getvalue()
+
+    def get_segments(
+            self,
+            project_id: int,
+            job_uid: str,
+            begin_index: int=0,
+            end_index: int=0,
+    ) -> List[models.Segment]:
+        """Call get segments API.
+
+        NOTE: I don't know why this endpoint returns list of list.
+        It seems always one item in outer list.
+
+        :param project_id: ID of the project
+        :param job_uid: UID of the job
+        :param begin_index
+        :param end_index
+        :return: List of models.Segment
+        """
+        segments = self._get("v1/projects/{}/jobs/{}/segments".format(project_id, job_uid), {
+            "beginIndex": begin_index,
+            "endIndex": end_index,
+        })
+
+        return [
+            models.Segment(segment) for segment in segments["segments"]
+        ]
+
+    def get(self, project_id: int, job_uid: str) -> models.Job:
+        """Get the job data.
+
+        :param job_uid: ID of the job.
+        :return: The retrieved job.
+        """
+        response = self._get("v1/projects/{}/jobs/{}".format(project_id, job_uid))
+
+        return models.Job(response)
+
+    def list(self, project_id: int) -> List[models.Job]:
+        """Get the jobs data.
+
+        :param project_id: ID of the project
+        :return: The retrieved jobs.
+        """
+        response = self._get("v2/projects/{}/jobs".format(project_id))
+
+        return [models.Job(i) for i in response["content"]]
+
+    def delete(
+            self,
+            project_id: int,
+            job_uids: List[int],
+            purge: bool=False
+    ) -> None:
+        """Delete a job
+
+        :param job_uids: ids of job you want to delete.
+        :param purge:
+        """
+        self._delete(
+            path="v1/projects/{}/jobs/batch".format(project_id),
+            params={"purge": purge},
+            data={"jobs": [{"uid": job_uid} for job_uid in job_uids]},
+        )
+
+    def set_status(
+            self,
+            project_id: int,
+            job_uid: str,
+            status: constants.JobStatusRest,
+    ) -> None:
+        """Update job status
+
+        JobStatus: New, Emailed, Assigned, Declined_By_Linguist,
+                   Completed_By_Linguist, Completed, Cancelled
+
+        :param job_part_id: id of job you want to update.
+        :param status: status of job to update. Acceptable type is JobStatus constant.
+        """
+        self._post("v1/projects/{}/jobs/{}/setStatus".format(project_id, job_uid), {
+            'requestedStatus': status.value
+        })
+
+    def delete_all_translations(
+            self,
+            project_id: int,
+            job_uids: List[int]
+    ) -> None:
+        """Delete all translations from a job
+
+        :param job_part_ids: IDs of job_part for the jobs.
+        """
+        self._delete("v1/projects/{}/jobs/translations".format(project_id), {}, {
+            'jobs': [{"uid": job_uid} for job_uid in job_uids],
+        })

--- a/memsource/api_rest/job.py
+++ b/memsource/api_rest/job.py
@@ -1,7 +1,6 @@
 import io
 import json
 import os
-import types
 import uuid
 from typing import Any, Dict, List
 
@@ -116,7 +115,7 @@ class Job(api_rest.BaseApi):
             self,
             project_id: int,
             job_parts: List[Dict[str, str]],
-            translation_memory_threshold: float=0.7,
+            translation_memory_threshold: float=constants.TM_THRESHOLD,
             callback_url: str=None,
     ) -> models.AsynchronousRequest:
         """Call async pre translate API.
@@ -138,13 +137,13 @@ class Job(api_rest.BaseApi):
 
         :param job_uid: job UID.
         """
-        def get_completed_file_stream() -> types.GeneratorType:
-            return self._get_stream(
-                "v1/projects/{}/jobs/{}/targetFile".format(project_id, job_uid)
-            ).iter_content(constants.CHUNK_SIZE)
+        data_stream = self._get_stream(
+            "v1/projects/{}/jobs/{}/targetFile".format(project_id, job_uid)
+        ).iter_content(constants.CHUNK_SIZE)
 
         buffer = io.BytesIO()
-        [buffer.write(chunk) for chunk in get_completed_file_stream()]
+        for chunk in data_stream:
+            buffer.write(chunk)
 
         return buffer.getvalue()
 

--- a/memsource/constants.py
+++ b/memsource/constants.py
@@ -69,3 +69,4 @@ class JobStatusRest(enum.Enum):
 
 CHUNK_SIZE = 1024
 CHAR_SET = "UTF-8"
+TM_THRESHOLD = 0.7

--- a/memsource/constants.py
+++ b/memsource/constants.py
@@ -48,11 +48,23 @@ class HttpMethod(enum.Enum):
     get = 'get'
     post = 'post'
     put = 'put'
+    delete = "delete"
 
 
 class BaseRest(enum.Enum):
     url = 'https://cloud.memsource.com/web/api2'
     timeout = 60
+
+
+class JobStatusRest(enum.Enum):
+    NEW = "NEW"
+    ACCEPTED = "ACCEPTED"
+    DECLINED = "DECLINED"
+    REJECTED = "REJECTED"
+    DELIVERED = "DELIVERED"
+    EMAILED = "EMAILED"
+    COMPLETED = "COMPLETED"
+    CANCELLED = "CANCELLED"
 
 
 CHUNK_SIZE = 1024

--- a/test/api_rest/test_job.py
+++ b/test/api_rest/test_job.py
@@ -1,0 +1,484 @@
+import uuid
+
+import requests
+import unittest
+from unittest.mock import patch, PropertyMock
+
+from memsource import models, exceptions, constants
+from memsource.api_rest.job import Job
+
+
+class TestApiJob(unittest.TestCase):
+    @patch("builtins.open")
+    @patch.object(requests.Session, "request")
+    def test_create(
+        self,
+        mock_request: unittest.mock.Mock,
+        mock_open: unittest.mock.Mock,
+    ):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+        mock_request().json.return_value = {
+            "unsupportedFiles": [],
+            "jobs": [
+                {
+                    "workflowLevel": 1,
+                    "filename": "requirements.txt",
+                    "targetLang": "ja",
+                    "notificationIntervalInMinutes": -1,
+                    "workflowStep": None,
+                    "uid": "0khOFZ70PYDzIAz0CvU0Fn",
+                    "updateSourceDate": None,
+                    "providers": [],
+                    "status": "NEW",
+                    "continuous": False,
+                    "imported": False,
+                    "dateDue": None,
+                    "jobAssignedEmailTemplate": None,
+                    "dateCreated": "2020-06-24T03:40:53+0000"
+                },
+            ],
+            "asyncRequest": {
+                "id": "381708066",
+                "action": "IMPORT_JOB",
+                "dateCreated": "2020-06-24T03:40:53+0000"
+            }
+        }
+
+        mock_open.return_value.__enter__.return_value.name = "this_is_a_test.txt"
+        returned_value = Job(token="mock-token").create(
+            1234,
+            "test/this_is_a_test.txt",
+            ["ja"]
+        )
+
+        # Don"t use assert_called_with because files has file object. It is difficult to test.
+        self.assertTrue(mock_request.called)
+        (called_args, called_kwargs) = mock_request.call_args
+
+        # hard to test
+        del called_kwargs["files"]
+
+        self.assertEqual(
+            (
+                constants.HttpMethod.post.value,
+                "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs",
+            ),
+            called_args
+        )
+
+        self.assertEqual({
+            "headers": {
+                "Content-Disposition": "inline; filename=\"this_is_a_test.txt\"",
+                "Content-Type": "application/octet-stream",
+                "Memsource": "{\"targetLangs\": [\"ja\"]}"
+            },
+            "json": {"targetLangs": ["ja"]},
+            "params": {"token": "mock-token"},
+            "timeout": 60,
+        }, called_kwargs)
+
+        self.assertEqual(1, len(returned_value))
+        for job_part in returned_value:
+            self.assertIsInstance(job_part, models.JobPart)
+
+    @patch("shutil.copy")
+    @patch("builtins.open")
+    @patch.object(requests.Session, "request")
+    def test_create_with_unsupported_file(
+        self,
+        mock_request: unittest.mock.Mock,
+        mock_open: unittest.mock.Mock,
+        mock_copy: unittest.mock.Mock,
+    ):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+        mock_request().json.return_value = {
+            "unsupportedFiles": ["test_runner.sh"],
+            "jobs": [],
+            "asyncRequest": {
+                "dateCreated": "2020-06-24T05:12:27+0000",
+                "id": "381726629",
+                "action": "IMPORT_JOB"
+            }
+        }
+
+        self.assertRaises(
+            exceptions.MemsourceUnsupportedFileException,
+            lambda: Job(token="mock-token").create(1234, "failed.txt", ["ja"]),
+        )
+        self.assertTrue(mock_request.called)
+
+    @patch("builtins.open")
+    @patch.object(uuid, "uuid1")
+    @patch.object(requests.Session, "request")
+    def test_create_from_text(
+        self,
+        mock_request: unittest.mock.Mock,
+        mock_uuid1: unittest.mock.Mock,
+        mock_open: unittest.mock.Mock,
+    ):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+        mock_request().json.return_value = {
+            "unsupportedFiles": [],
+            "jobs": [
+                {
+                    "workflowLevel": 1,
+                    "filename": "requirements.txt",
+                    "targetLang": "ja",
+                    "notificationIntervalInMinutes": -1,
+                    "workflowStep": None,
+                    "uid": "0khOFZ70PYDzIAz0CvU0Fn",
+                    "updateSourceDate": None,
+                    "providers": [],
+                    "status": "NEW",
+                    "continuous": False,
+                    "imported": False,
+                    "dateDue": None,
+                    "jobAssignedEmailTemplate": None,
+                    "dateCreated": "2020-06-24T03:40:53+0000"
+                },
+            ],
+            "asyncRequest": {
+                "id": "381708066",
+                "action": "IMPORT_JOB",
+                "dateCreated": "2020-06-24T03:40:53+0000"
+            }
+        }
+
+        mock_uuid1().hex = "test-file-uuid1"
+
+        mock_open.return_value.__enter__.return_value.name = "test-file-uuid1.txt"
+        returned_value = Job(token="mock-token").create_from_text(
+            1234,
+            "this is a test",
+            ["ja"]
+        )
+
+        # Don"t use assert_called_with because files has file object. It is difficult to test.
+        self.assertTrue(mock_request.called)
+        (called_args, called_kwargs) = mock_request.call_args
+
+        # hard to test
+        del called_kwargs["files"]
+
+        self.assertEqual(
+            (
+                constants.HttpMethod.post.value,
+                "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs",
+            ),
+            called_args
+        )
+
+        self.assertEqual({
+            "headers": {
+                "Content-Disposition": "inline; filename=\"test-file-uuid1.txt\"",
+                "Content-Type": "application/octet-stream",
+                "Memsource": "{\"targetLangs\": [\"ja\"]}"
+            },
+            "json": {"targetLangs": ["ja"]},
+            "params": {"token": "mock-token"},
+            "timeout": 60,
+        }, called_kwargs)
+
+        self.assertEqual(1, len(returned_value))
+        for job_part in returned_value:
+            self.assertIsInstance(job_part, models.JobPart)
+
+    @patch.object(requests.Session, "request")
+    def test_list_by_project(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+
+        project_id = 1234
+
+        mock_request().json.return_value = {
+            "content": [
+                {
+                    "imported": True,
+                    "targetLang": "ja",
+                    "dateCreated": "2020-06-24T03:38:31+0000",
+                    "filename": "requirements.txt",
+                    "uid": "06CcWsyrLLTTgylLQ9DSb6",
+                    "providers": [],
+                    "status": "NEW",
+                    "continuous": False,
+                    "dateDue": None,
+                    "workflowStep": None
+                },
+                {
+                    "imported": True,
+                    "targetLang": "ja",
+                    "dateCreated": "2020-06-24T03:40:53+0000",
+                    "filename": "requirements.txt",
+                    "uid": "0khOFZ70PYDzIAz0CvU0Fn",
+                    "providers": [],
+                    "status": "NEW",
+                    "continuous": False,
+                    "dateDue": None,
+                    "workflowStep": None
+                }
+            ],
+            "totalElements": 2,
+            "pageSize": 50,
+            "totalPages": 1,
+            "pageNumber": 0,
+            "numberOfElements": 2,
+        }
+
+        returned_value = Job(token="mock-token").list_by_project(project_id)
+
+        for job_part in returned_value:
+            self.assertIsInstance(job_part, models.JobPart)
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.get.value,
+            "https://cloud.memsource.com/web/api2/v2/projects/1234/jobs",
+            params={"token": "mock-token", "page": 0},
+            timeout=60,
+        )
+
+        self.assertEqual(len(returned_value), 2)
+
+    @patch.object(requests.Session, "request")
+    def test_pre_translate_no_callback(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+
+        job_part_ids = [1, 2]
+
+        mock_request().json.return_value = {
+            "asyncRequest": {
+                "createdBy": {
+                    "lastName": "test",
+                    "id": 1,
+                    "firstName": "admin",
+                    "role": "ADMIN",
+                    "email": "test@test.com",
+                    "userName": "admin",
+                    "active": True
+                },
+                "action": "PRE_TRANSLATE",
+                "id": 4567,
+                "dateCreated": "2014-11-03T16:03:11Z",
+                "asyncResponse": None
+            }
+        }
+
+        retuned_value = Job(token="mock-token").pre_translate(1234, job_part_ids)
+
+        self.assertIsInstance(retuned_value, models.AsynchronousRequest)
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.post.value,
+            "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/preTranslate",
+            json={
+                "jobs": [
+                    {"uid": 1},
+                    {"uid": 2},
+                ],
+                "translationMemoryTreshold": 0.7,
+                "callbackUrl": None,
+            },
+            params={"token": "mock-token"},
+            timeout=60,
+        )
+
+    @patch.object(requests.Session, "request")
+    def test_get_completed_file_text(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+
+        mock_request().iter_content.return_value = [b"test completed content", b"second"]
+        returned_value = Job(token="mock-token").get_completed_file_text(1234, 1)
+
+        self.assertEqual(b"test completed contentsecond", returned_value)
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.get.value,
+            "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/1/targetFile",
+            params={"token": "mock-token"},
+            timeout=60 * 5,
+        )
+
+    @patch.object(requests.Session, "request")
+    def test_get_segments(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+        mock_request().json.return_value = {
+            "segments": [
+                {
+                    "id": "dz0ksG9dBy0TGIYu1_dc6:0",
+                    "source": "Hello",
+                    "workflowStep": None,
+                    "createdBy": {},
+                    "modifiedAt": 1592984050930,
+                    "translation": "Ola",
+                    "modifiedBy": {},
+                    "createdAt": 1592984050693,
+                    "workflowLevel": None
+                },
+                {
+                    "id": "dz0ksG9dBy0TGIYu1_dc6:1",
+                    "source": " World",
+                    "workflowStep": None,
+                    "createdBy": {},
+                    "modifiedAt": 1592985077488,
+                    "translation": "",
+                    "modifiedBy": {},
+                    "createdAt": 1592985077488,
+                    "workflowLevel": None
+                }
+            ]
+        }
+
+        returned_value = Job(token="mock-token").get_segments(
+            project_id=1234,
+            job_uid="mock-uid",
+            begin_index=0,
+            end_index=1,
+        )
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.get.value,
+            "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/mock-uid/segments",
+            params={
+                "beginIndex": 0,
+                "endIndex": 1,
+                "token": "mock-token",
+            },
+            timeout=60,
+        )
+
+        for segment in returned_value:
+            self.assertIsInstance(segment, models.Segment)
+
+    @patch.object(requests.Session, "request")
+    def test_get(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+        mock_request().json.return_value = {
+            'status': 'NEW',
+            'filename': 'requirements.txt',
+            'workflowLevel': 1,
+            'project': {},
+            'workflowStep': None,
+            'originalFileDirectory': '',
+            'isParentJobSplit': False,
+            'endIndex': 12,
+            'dateCreated': '2020-06-24T03:38:31+0000',
+            'wordsCount': 22,
+            'continuousJobInfo': None,
+            'workUnit': None,
+            'sourceLang': 'en',
+            'beginIndex': 0,
+            'continuous': False,
+            'updateSourceDate': None,
+            'targetLang': 'ja',
+            'uid': '06CcWsyrLLTTgylLQ9DSb6',
+            'lastWorkflowLevel': 1
+        }
+
+        returned_value = Job(token="mock-token").get(1234, "06CcWsyrLLTTgylLQ9DSb6")
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.get.value,
+            "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/06CcWsyrLLTTgylLQ9DSb6",
+            params={"token": "mock-token"},
+            timeout=60,
+        )
+
+        self.assertEqual("NEW", returned_value.status)
+
+    @patch.object(requests.Session, "request")
+    def test_list(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+
+        mock_request().json.return_value = {
+            "totalPages": 1,
+            "pageNumber": 0,
+            "totalElements": 2,
+            "content": [
+                {
+                    "filename": "requirements.txt",
+                    "continuous": False,
+                    "dateDue": None,
+                    "uid": "06CcWsyrLLTTgylLQ9DSb6",
+                    "status": "NEW",
+                    "targetLang": "ja",
+                    "workflowStep": None,
+                    "imported": True,
+                    "providers": [],
+                    "dateCreated": "2020-06-24T03:38:31+0000"
+                },
+                {
+                    "filename": "requirements.txt",
+                    "continuous": False,
+                    "dateDue": None,
+                    "uid": "0khOFZ70PYDzIAz0CvU0Fn",
+                    "status": "NEW",
+                    "targetLang": "ja",
+                    "workflowStep": None,
+                    "imported": True,
+                    "providers": [],
+                    "dateCreated": "2020-06-24T03:40:53+0000"
+                }
+            ],
+            "pageSize": 50,
+            "numberOfElements": 2,
+        }
+
+        returned_value = Job(token="mock-token").list(1234)
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.get.value,
+            "https://cloud.memsource.com/web/api2/v2/projects/1234/jobs",
+            params={"token": "mock-token"},
+            timeout=60,
+        )
+
+        self.assertEqual("NEW", returned_value[0].status)
+
+    @patch.object(requests.Session, "request")
+    def test_delete(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=204)
+        mock_request().json.return_value = None
+
+        self.assertIsNone(Job(token="mock-token").delete(1234, [1, 2]))
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.delete.value,
+            "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/batch",
+            params={"purge": False, "token": "mock-token"},
+            json={
+                "jobs": [
+                    {"uid": 1},
+                    {"uid": 2},
+                ],
+            },
+            timeout=60,
+        )
+
+    @patch.object(requests.Session, "request")
+    def test_set_status(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=204)
+        mock_request().json.return_value = None
+
+        self.assertIsNone(Job(token="mock-token").set_status(
+            1234, 1, constants.JobStatusRest.DECLINED))
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.post.value,
+            "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/1/setStatus",
+            json={"requestedStatus": "DECLINED"},
+            params={"token": "mock-token"},
+            timeout=60
+        )
+
+    @patch.object(requests.Session, "request")
+    def test_delete_all_translations(self, mock_request):
+        type(mock_request()).status_code = PropertyMock(return_value=204)
+        self.assertIsNone(Job(token="mock-token").delete_all_translations(1234, ["mock-job-uid"]))
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.delete.value,
+            "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/translations",
+            params={"token": "mock-token"},
+            json={
+                "jobs": [{"uid": "mock-job-uid"}],
+            },
+            timeout=60,
+        )


### PR DESCRIPTION
### Description
- Introduce a Job class that will use the new Memsource REST API.
- Introduce a `_delete` method that will handle DELETE requests.
- Some Memsource resources returns 204 for a DELETE request which `response.json()` throws an error. Handle this by checking if the status_code is 204 and return an empty dictionary instead. [Requests.json()](https://requests.readthedocs.io/en/master/user/quickstart/#json-response-content)

- For now, we will only support what we already have.

https://github.com/gengo/memsource-wrap/blob/bd6db2e866ae5ca0e66aca5e77ea44af716d9a3a/memsource/api.py#L385-L623