### PR TITLE
Add rest switch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file. Dates are i
 
 Unreleased
 ==========
+[0.5.7] - 2020-06-30
+====================
+
+Added
+-----
+- Added a new Analysis class for Memsource REST transition.
+- Added a function to upload bilingual files.
+- Added a switch for the REST implementation.
+
+Fix typehints
+-----
+- Some typehints gives an impression that it can accept a string when it should be a list of string.
+
 [0.5.6] - 2020-06-29
 ====================
 

--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.5.6'
+__version__ = '0.5.7'
 __license__ = 'MIT'

--- a/memsource/api_rest/analysis.py
+++ b/memsource/api_rest/analysis.py
@@ -1,0 +1,73 @@
+from typing import Iterator, List
+from memsource import api_rest, constants, models
+
+
+class Analysis(api_rest.BaseApi):
+    # Document: https://cloud.memsource.com/web/docs/api#tag/Analysis
+
+    def get(self, analysis_id: int) -> models.Analysis:
+        """Call get API.
+
+        :param analysis_id: Get analysis of this id.
+        :return: Result of analysis.
+        """
+        return models.Analysis(self._get("v3/analyses/{}".format(analysis_id)))
+
+    def create(self, jobs: List[int]) -> models.AsynchronousRequest:
+        """Create new analysis.
+
+        :param jobs: Target of analysis.
+        :return: Result of analysis.
+        """
+        return models.AsynchronousRequest(self._post("v2/analyses", {
+            "jobs": [{"uid": job} for job in jobs],
+        }))
+
+    def delete(self, analysis_id: int, purge: bool=False) -> None:
+        """Delete an analysis.
+
+        :param analysis_id: Analysis ID you want to delete.
+        :param purge:
+        """
+        self._delete("v1/analyses/{}".format(analysis_id), {"purge": purge})
+
+    def get_by_project(self, project_id: str) -> List[models.Analysis]:
+        """List Analyses By Project.
+
+        :param project_id: Project ID for which you want to get the analyses.
+        :return: List of Analyses.
+        """
+        project_analyses = self._get("v2/projects/{}/analyses".format(project_id))
+        return [models.Analysis(analysis) for analysis in project_analyses["content"]]
+
+    def download(
+            self,
+            analysis_id: int,
+            dest_file_path: str,
+            file_format: constants.AnalysisFormat=constants.AnalysisFormat.CSV,
+    ) -> None:
+        """Download analysis into specified file format.
+
+        :param analysis_id: Anaylsis ID for which you download.
+        :param dest_file_path: Destination path where you want to download the file.
+        :param file_format: File format of file.
+        :return: Downloaded file with content of the analysis
+        """
+        with open(dest_file_path, "wb") as f:
+            for chunk in self._get_analysis_stream(analysis_id, file_format):
+                f.write(chunk)
+
+    def _get_analysis_stream(
+            self,
+            analysis_id: int,
+            file_format: constants.AnalysisFormat
+    ) -> Iterator[bytes]:
+        """Process bytes return by API
+
+        :param analysis_id: Anaylsis ID for which you download.
+        :param file_format: File format of file.
+        :return: Downloaded analysis file with iterator.
+        """
+        return self._get_stream("v1/analyses/{}/download".format(analysis_id), {
+            "format": file_format.value,
+        }).iter_content(constants.CHUNK_SIZE)

--- a/memsource/api_rest/bilingual.py
+++ b/memsource/api_rest/bilingual.py
@@ -1,4 +1,5 @@
 import io
+import uuid
 from typing import Iterator, List
 
 from memsource import api_rest, constants, models
@@ -64,3 +65,15 @@ class Bilingual(api_rest.BaseApi):
         :returns: MxliffUnit
         """
         return mxliff.MxliffParser().parse(self.get_bilingual_file_xml(project_id, job_uids))
+
+    def upload_bilingual_file_from_xml(self, xml: str) -> List[models.Job]:
+        """Call uploadBilingualFile API.
+
+        :param xml: Upload this file.
+        """
+        extra_headers = {"Content-Type": "application/octet-stream"}
+        self.add_headers(extra_headers)
+
+        self._put("v1/bilingualFiles", None, {
+            "file": ("{}.mxliff".format(uuid.uuid1().hex), xml),
+        })

--- a/memsource/api_rest/project.py
+++ b/memsource/api_rest/project.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 from memsource import constants, models, api_rest
 
 
@@ -9,7 +9,7 @@ class Project(api_rest.BaseApi):
         self,
         name: str,
         source_lang: str,
-        target_langs: Union[List[str], Tuple[str], str],
+        target_langs: List[str],
         client: int=None,
         domain: int=None,
     ) -> int:

--- a/memsource/api_rest/project.py
+++ b/memsource/api_rest/project.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 from memsource import constants, models, api_rest
 
 

--- a/memsource/memsource.py
+++ b/memsource/memsource.py
@@ -1,8 +1,29 @@
 from . import api
+from memsource.api_rest import (
+    auth,
+    client,
+    domain,
+    language,
+    term_base,
+    project,
+    job,
+    bilingual,
+    tm,
+    analysis,
+)
 
 
 class Memsource(object):
-    def __init__(self, user_name=None, password=None, token=None, headers=None):
+    def __init__(self, user_name=None, password=None, token=None, headers=None, use_rest=False):
+        if use_rest:
+            self._init_rest(
+                user_name=user_name,
+                password=password,
+                token=token,
+                headers=headers,
+            )
+            return
+
         """
         If token is given, use the token.
         Otherwise authenticate with user_name and password, and get token.
@@ -21,3 +42,23 @@ class Memsource(object):
         self.language = api.Language(token, headers)
         self.analysis = api.Analysis(token, headers)
         self.term_base = api.TermBase(token, headers)
+
+    def _init_rest(self, user_name, password, token, headers):
+        """
+        If token is given, use the token.
+        Otherwise authenticate with user_name and password, and get token.
+        """
+        if user_name and password and not token and not headers:
+            token = auth.Auth().login(user_name, password).token
+
+        # make api class instances
+        self.auth = auth.Auth(token, headers)
+        self.client = client.Client(token, headers)
+        self.domain = domain.Domain(token, headers)
+        self.project = project.Project(token, headers)
+        self.job = job.Job(token, headers)
+        self.translation_memory = tm.TranslationMemory(token, headers)
+        self.language = language.Language(token, headers)
+        self.analysis = analysis.Analysis(token, headers)
+        self.term_base = term_base.TermBase(token, headers)
+        self.bilingual = bilingual.Bilingual(token, headers)

--- a/test/api_rest/test_analysis.py
+++ b/test/api_rest/test_analysis.py
@@ -47,7 +47,10 @@ class TestAnalysis(unittest.TestCase):
         }
 
         jobs = [1]
-        self.assertIsInstance(Analysis(token="mock-token").create(jobs), models.AsynchronousRequest)
+        self.assertIsInstance(
+            Analysis(token="mock-token").create(jobs),
+            models.AsynchronousRequest
+        )
 
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,

--- a/test/api_rest/test_analysis.py
+++ b/test/api_rest/test_analysis.py
@@ -1,0 +1,141 @@
+import requests
+import unittest
+from unittest.mock import patch, PropertyMock
+
+from memsource import constants, models
+from memsource.api_rest.analysis import Analysis
+
+
+class TestAnalysis(unittest.TestCase):
+    @patch.object(requests.Session, "request")
+    def test_get(self, mock_request: unittest.mock):
+        mock_request.return_value = unittest.mock.MagicMock(status_code=200)
+
+        Analysis(token="mock-token").get(1)
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.get.value,
+            "https://cloud.memsource.com/web/api2/v3/analyses/1",
+            params={"token": "mock-token"},
+            timeout=60,
+        )
+
+    @patch.object(requests.Session, "request")
+    def test_create(self, mock_request: unittest.mock.Mock):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+        mock_request().json.return_value = {
+            "asyncRequests": [
+                {
+                    "asyncRequest": {
+                        "createdBy": {
+                            "lastName": "test",
+                            "id": 1,
+                            "firstName": "admin",
+                            "role": "ADMIN",
+                            "email": "test@test.com",
+                            "userName": "admin",
+                            "active": True
+                        },
+                        "action": "PRE_ANALYSE",
+                        "id": "1",
+                        "dateCreated": "2014-11-03T16:03:11Z",
+                        "asyncResponse": None
+                    },
+                    "analyse": {"id": "string"},
+                }
+            ]
+        }
+
+        jobs = [1]
+        self.assertIsInstance(Analysis(token="mock-token").create(jobs), models.AsynchronousRequest)
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.post.value,
+            "https://cloud.memsource.com/web/api2/v2/analyses",
+            params={"token": "mock-token"},
+            json={"jobs": [{"uid": 1}]},
+            timeout=60,
+        )
+
+    @patch.object(requests.Session, "request")
+    def test_delete(self, mock_request: unittest.mock.Mock):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+        mock_request().json.return_value = None
+
+        analysis_id = 1234
+
+        self.assertIsNone(Analysis(token="mock-token").delete(analysis_id))
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.delete.value,
+            "https://cloud.memsource.com/web/api2/v1/analyses/1234",
+            params={"token": "mock-token", "purge": False},
+            timeout=60,
+        )
+
+    @patch.object(requests.Session, "request")
+    def test_get_by_project(self, mock_request: unittest.mock.Mock):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+        mock_request().json.return_value = {
+            "totalElements": 0,
+            "totalPages": 0,
+            "pageSize": 0,
+            "pageNumber": 0,
+            "numberOfElements": 0,
+            "content": [
+                {
+                    "id": "1",
+                    "type": "PreAnalyse",
+                    "name": "analysis",
+                    "provider": {},
+                    "createdBy": {},
+                    "dateCreated": "2014-11-03T16:03:11Z",
+                    "netRateScheme": {},
+                    "analyseLanguageParts": [],
+                },
+                {
+                    "id": "2",
+                    "type": "PreAnalyse",
+                    "name": "analysis-2",
+                    "provider": {},
+                    "createdBy": {},
+                    "dateCreated": "2014-11-03T16:03:11Z",
+                    "netRateScheme": {},
+                    "analyseLanguageParts": [],
+                }
+            ]
+        }
+
+        project_id = 1234
+
+        analyses = Analysis(token="mock-token").get_by_project(project_id)
+
+        self.assertIsInstance(analyses, list)
+        for analysis in analyses:
+            self.assertIsInstance(analysis, models.Analysis)
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.get.value,
+            "https://cloud.memsource.com/web/api2/v2/projects/1234/analyses",
+            params={"token": "mock-token"},
+            timeout=60,
+        )
+
+    @patch("builtins.open")
+    @patch.object(requests.Session, "request")
+    def test_download(self, mock_request: unittest.mock.Mock, mock_open: unittest.mock.Mock):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+
+        analysis = "this is analysis"
+
+        mock_request().iter_content.return_value = [
+            bytes(content, 'utf-8') for content in analysis]
+        analysis_id = 1234
+
+        Analysis(token="mock-token").download(analysis_id, "test.csv")
+        mock_request.assert_called_with(
+            constants.HttpMethod.get.value,
+            "https://cloud.memsource.com/web/api2/v1/analyses/1234/download",
+            params={"token": "mock-token", "format": constants.AnalysisFormat.CSV.value},
+            timeout=300,
+        )

--- a/test/api_rest/test_bilingual.py
+++ b/test/api_rest/test_bilingual.py
@@ -1,6 +1,7 @@
 import os
 import requests
 import unittest
+import uuid
 from unittest.mock import patch, PropertyMock
 
 from memsource import constants, models
@@ -117,4 +118,26 @@ class TestBilingual(unittest.TestCase):
             },
             json={"jobs": [{"uid": 1}, {"uid": 2}]},
             timeout=60,
+        )
+
+    @patch.object(uuid, "uuid1")
+    @patch.object(requests.Session, "request")
+    def test_upload_bilingual_file_from_xml(
+            self,
+            mock_request: unittest.mock.Mock,
+            mock_uuid1: unittest.mock.Mock
+    ):
+        type(mock_request()).status_code = PropertyMock(return_value=200)
+
+        xml = "<xml>this is test</xml>"
+        mock_uuid1().hex = "test_file"
+
+        Bilingual(token="mock-token").upload_bilingual_file_from_xml(xml)
+
+        mock_request.assert_called_with(
+            constants.HttpMethod.put.value,
+            "https://cloud.memsource.com/web/api2/v1/bilingualFiles",
+            params={"token": "mock-token"},
+            files={"file": ("test_file.mxliff", xml)},
+            timeout=constants.Base.timeout.value
         )


### PR DESCRIPTION
### Description
- Added a function to upload bilingual files.
- Added a switch for the REST implementation.
- Some typehints gives an impression that it can accept a string when it should be a list of string.
- Introduce an Analysis class that will use the new Memsource REST API.

https://github.com/gengo/memsource-wrap/blob/8093c470e4e5e591eef37aec5eb39b2edfd55e79/memsource/api.py#L1001-L1072