### PR TITLE
Include api rest directory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file. Dates are i
 
 Unreleased
 ==========
+[0.5.8] - 2020-07-01
+====================
+
+Fix
+-----
+- Include api_rest directory in setup
+
 [0.5.7] - 2020-06-30
 ====================
 

--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.5.7'
+__version__ = '0.5.8'
 __license__ = 'MIT'

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     author_email='devops@gengo.com',
     url='https://github.com/gengo/memsource-wrap',
     keywords='Memsource API',
-    packages=('memsource', 'memsource.lib'),
+    packages=('memsource', 'memsource.lib', 'memsource.api_rest'),
     install_requires=parse_requirements(),
 )


### PR DESCRIPTION
## Description
- We need to include the `api_rest` directory for it to work.
