### PR TITLE
TM import segments fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file. Dates are i
 
 Unreleased
 ==========
+[0.5.9] - 2020-07-02
+====================
+
+Fix
+-----
+- TM Import segments bugfix
+
 [0.5.8] - 2020-07-01
 ====================
 

--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.5.8'
+__version__ = '0.5.9'
 __license__ = 'MIT'


### PR DESCRIPTION
### Description
- Encountered an issue when importing segments back to Memsource and pinpointed it into when we use the `files` parameter. For a workaround, we use the `data` parameter instead.
- Use tempfile instead of passing tuple when uploading from text.

### Screenshot
<img width="1089" alt="Screen Shot 2020-07-02 at 12 38 44 PM" src="https://user-images.githubusercontent.com/6194312/86317063-0f22a600-bc61-11ea-80e7-14aec33f3f47.png">
