### PR TITLE
moved the deprecated "token" in the query string to the "Authorization" header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,13 @@ Change Log
 ==========
 All notable changes to this project will be documented in this file. Dates are in UTC.
 
-Unreleased
-==========
+[0.6.0] - 2022-10-18
+====================
+
+Changed
+-------
+- Moved the deprecated "token" in the query string to the "Authorization" header
+
 [0.5.9] - 2020-07-02
 ====================
 

--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Gengo'
-__version__ = '0.5.9'
+__version__ = '0.6.0'
 __license__ = 'MIT'

--- a/memsource/api_rest/__init__.py
+++ b/memsource/api_rest/__init__.py
@@ -96,7 +96,7 @@ class BaseApi:
             http_method=constants.HttpMethod.post,
             path=path,
             files=files,
-            params={"token": self.token},
+            params={},
             data=data,
             timeout=timeout
         )
@@ -148,7 +148,7 @@ class BaseApi:
             http_method=constants.HttpMethod.put,
             path=path,
             files=files,
-            params={"token": self.token},
+            params={},
             data=data,
             timeout=timeout
         ).json()
@@ -193,7 +193,7 @@ class BaseApi:
         :return: Tuple of URL and params with token.
         """
         url = "{}/{}".format(constants.BaseRest.url.value, path)
-        params['token'] = self.token
+        self.add_headers({"Authorization": "ApiToken {}".format(self.token)})
 
         self.last_url = url
         self.last_params = params

--- a/test/api_rest/test_analysis.py
+++ b/test/api_rest/test_analysis.py
@@ -16,7 +16,7 @@ class TestAnalysis(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v3/analyses/1",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60,
         )
 
@@ -55,7 +55,7 @@ class TestAnalysis(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v2/analyses",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             json={"jobs": [{"uid": 1}]},
             timeout=60,
         )
@@ -72,7 +72,8 @@ class TestAnalysis(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.delete.value,
             "https://cloud.memsource.com/web/api2/v1/analyses/1234",
-            params={"token": "mock-token", "purge": False},
+            headers={"Authorization": "ApiToken mock-token"},
+            params={"purge": False},
             timeout=60,
         )
 
@@ -120,7 +121,7 @@ class TestAnalysis(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v2/projects/1234/analyses",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60,
         )
 
@@ -139,6 +140,7 @@ class TestAnalysis(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/analyses/1234/download",
-            params={"token": "mock-token", "format": constants.AnalysisFormat.CSV.value},
+            headers={"Authorization": "ApiToken mock-token"},
+            params={"format": constants.AnalysisFormat.CSV.value},
             timeout=300,
         )

--- a/test/api_rest/test_base_api.py
+++ b/test/api_rest/test_base_api.py
@@ -49,8 +49,11 @@ class TestBaseApi(unittest.TestCase):
         api = api_rest.BaseApi(token="TEST-TOKEN")
         response = api._get("v1/path", {"jobUID": 1})
         mock_request.assert_called_once_with(
-            "get", "https://cloud.memsource.com/web/api2/v1/path",
-            params={"jobUID": 1, "token": "TEST-TOKEN"}, timeout=60,
+            "get",
+            "https://cloud.memsource.com/web/api2/v1/path",
+            headers={"Authorization": "ApiToken TEST-TOKEN"},
+            params={"jobUID": 1},
+            timeout=60,
         )
         self.assertIsInstance(response, dict)
 
@@ -61,8 +64,11 @@ class TestBaseApi(unittest.TestCase):
         api = api_rest.BaseApi(token="TEST-TOKEN")
         api._get_stream("v1/path", {"jobUID": 1})
         mock_request.assert_called_once_with(
-            "get", "https://cloud.memsource.com/web/api2/v1/path",
-            params={"jobUID": 1, "token": "TEST-TOKEN"}, timeout=300,
+            "get",
+            "https://cloud.memsource.com/web/api2/v1/path",
+            headers={"Authorization": "ApiToken TEST-TOKEN"},
+            params={"jobUID": 1},
+            timeout=300,
         )
 
     @patch.object(requests.Session, "request")
@@ -72,5 +78,5 @@ class TestBaseApi(unittest.TestCase):
         api._post("v2/path", {"jobUID": 1})
         mock_request.assert_called_once_with(
             "post", "https://cloud.memsource.com/web/api2/v2/path",
-            json={"jobUID": 1}, params={"token": "TEST-TOKEN"}, timeout=60,
+            json={"jobUID": 1}, headers={"Authorization": "ApiToken TEST-TOKEN"}, timeout=60,
         )

--- a/test/api_rest/test_bilingual.py
+++ b/test/api_rest/test_bilingual.py
@@ -32,7 +32,7 @@ class TestBilingual(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/bilingualFile",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             json={"jobs": [{"uid": 1}, {"uid": 2}]},
             timeout=60,
         )
@@ -55,9 +55,7 @@ class TestBilingual(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/bilingualFile",
-            params={
-                "token": "mock-token",
-            },
+            headers={"Authorization": "ApiToken mock-token"},
             json={"jobs": [{"uid": 1}, {"uid": 2}]},
             timeout=60,
         )
@@ -113,9 +111,7 @@ class TestBilingual(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/bilingualFile",
-            params={
-                "token": "mock-token",
-            },
+            headers={"Authorization": "ApiToken mock-token"},
             json={"jobs": [{"uid": 1}, {"uid": 2}]},
             timeout=60,
         )
@@ -137,7 +133,7 @@ class TestBilingual(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.put.value,
             "https://cloud.memsource.com/web/api2/v1/bilingualFiles",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             files={"file": ("test_file.mxliff", xml)},
             timeout=constants.Base.timeout.value
         )

--- a/test/api_rest/test_domain.py
+++ b/test/api_rest/test_domain.py
@@ -25,7 +25,7 @@ class TestDomain(unittest.TestCase):
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/domains",
             json={"name": "mock-test"},
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60
         )
 
@@ -48,7 +48,7 @@ class TestDomain(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/domains/1",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60
         )
 
@@ -78,7 +78,8 @@ class TestDomain(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/domains",
-            params={"token": "mock-token", "page": 0},
+            headers={"Authorization": "ApiToken mock-token"},
+            params={"page": 0},
             timeout=60
         )
 

--- a/test/api_rest/test_job.py
+++ b/test/api_rest/test_job.py
@@ -70,10 +70,10 @@ class TestApiJob(unittest.TestCase):
             "headers": {
                 "Content-Disposition": "inline; filename=\"this_is_a_test.txt\"",
                 "Content-Type": "application/octet-stream",
-                "Memsource": "{\"targetLangs\": [\"ja\"]}"
+                "Memsource": "{\"targetLangs\": [\"ja\"]}",
+                "Authorization": "ApiToken mock-token",
             },
             "json": {"targetLangs": ["ja"]},
-            "params": {"token": "mock-token"},
             "timeout": 60,
         }, called_kwargs)
 
@@ -172,10 +172,10 @@ class TestApiJob(unittest.TestCase):
             "headers": {
                 "Content-Disposition": "inline; filename=\"test-file-uuid1.txt\"",
                 "Content-Type": "application/octet-stream",
-                "Memsource": "{\"targetLangs\": [\"ja\"]}"
+                "Memsource": "{\"targetLangs\": [\"ja\"]}",
+                "Authorization": "ApiToken mock-token",
             },
             "json": {"targetLangs": ["ja"]},
-            "params": {"token": "mock-token"},
             "timeout": 60,
         }, called_kwargs)
 
@@ -231,7 +231,8 @@ class TestApiJob(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v2/projects/1234/jobs",
-            params={"token": "mock-token", "page": 0},
+            headers={"Authorization": "ApiToken mock-token"},
+            params={"page": 0},
             timeout=60,
         )
 
@@ -268,6 +269,7 @@ class TestApiJob(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/preTranslate",
+            headers={"Authorization": "ApiToken mock-token"},
             json={
                 "jobs": [
                     {"uid": 1},
@@ -276,7 +278,6 @@ class TestApiJob(unittest.TestCase):
                 "translationMemoryTreshold": 0.7,
                 "callbackUrl": None,
             },
-            params={"token": "mock-token"},
             timeout=60,
         )
 
@@ -292,7 +293,7 @@ class TestApiJob(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/1/targetFile",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60 * 5,
         )
 
@@ -336,10 +337,10 @@ class TestApiJob(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/mock-uid/segments",
+            headers={"Authorization": "ApiToken mock-token"},
             params={
                 "beginIndex": 0,
                 "endIndex": 1,
-                "token": "mock-token",
             },
             timeout=60,
         )
@@ -377,7 +378,7 @@ class TestApiJob(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/06CcWsyrLLTTgylLQ9DSb6",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60,
         )
 
@@ -426,7 +427,7 @@ class TestApiJob(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v2/projects/1234/jobs",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60,
         )
 
@@ -442,7 +443,8 @@ class TestApiJob(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.delete.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/batch",
-            params={"purge": False, "token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
+            params={"purge": False},
             json={
                 "jobs": [
                     {"uid": 1},
@@ -463,8 +465,8 @@ class TestApiJob(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/1/setStatus",
+            headers={"Authorization": "ApiToken mock-token"},
             json={"requestedStatus": "DECLINED"},
-            params={"token": "mock-token"},
             timeout=60
         )
 
@@ -476,7 +478,7 @@ class TestApiJob(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.delete.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1234/jobs/translations",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             json={
                 "jobs": [{"uid": "mock-job-uid"}],
             },

--- a/test/api_rest/test_language.py
+++ b/test/api_rest/test_language.py
@@ -31,6 +31,6 @@ class TestLanguage(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/languages",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60,
         )

--- a/test/api_rest/test_project.py
+++ b/test/api_rest/test_project.py
@@ -32,6 +32,7 @@ class TestProject(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/projects",
+            headers={"Authorization": "ApiToken mock-token"},
             json={
                 "sourceLang": "en",
                 "targetLangs": ["ja", "de"],
@@ -39,7 +40,6 @@ class TestProject(unittest.TestCase):
                 "name": "mock-project",
                 "domain": None
             },
-            params={"token": "mock-token"},
             timeout=60,
         )
 
@@ -127,7 +127,8 @@ class TestProject(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/projects",
-            params={"token": "mock-token", "statuses": ["NEW", "ASSIGNED"]},
+            headers={"Authorization": "ApiToken mock-token"},
+            params={"statuses": ["NEW", "ASSIGNED"]},
             timeout=60,
         )
 
@@ -238,7 +239,7 @@ class TestProject(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1/transMemories",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60,
         )
 
@@ -259,13 +260,13 @@ class TestProject(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.put.value,
             "https://cloud.memsource.com/web/api2/v2/projects/1/transMemories",
+            headers={"Authorization": "ApiToken mock-token"},
             json={
                 "targetLang": "ja",
                 "transMemories": [
                     {"readMode": True, "transMemory": {"id": "1180298"}, "writeMode": True}
                 ],
             },
-            params={"token": "mock-token"},
             timeout=60,
         )
 
@@ -281,8 +282,8 @@ class TestProject(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1/setStatus",
+            headers={"Authorization": "ApiToken mock-token"},
             json={"status": "NEW"},
-            params={"token": "mock-token"},
             timeout=60,
         )
 
@@ -361,6 +362,6 @@ class TestProject(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/projects/1/termBases",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60,
         )

--- a/test/api_rest/test_term_base.py
+++ b/test/api_rest/test_term_base.py
@@ -17,7 +17,8 @@ class TestTermBase(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/termBases/1/export",
-            params={"format": "Xlsx", "charset": "UTF-8", "token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
+            params={"format": "Xlsx", "charset": "UTF-8"},
             timeout=300,
         )
         mock_open.assert_called_with('mock-local-filepath', 'wb')

--- a/test/api_rest/test_tm.py
+++ b/test/api_rest/test_tm.py
@@ -29,7 +29,7 @@ class TestApiTranslationMemory(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/transMemories",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             json={
                 "name": name,
                 "sourceLang": source_lang,
@@ -56,7 +56,8 @@ class TestApiTranslationMemory(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/transMemories",
-            params={"token": "mock-token", "pageNumber": 0},
+            headers={"Authorization": "ApiToken mock-token"},
+            params={"pageNumber": 0},
             timeout=60,
         )
 
@@ -78,7 +79,8 @@ class TestApiTranslationMemory(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/transMemories",
-            params={"token": "mock-token", "pageNumber": EXISTING_PAGE_ID},
+            headers={"Authorization": "ApiToken mock-token"},
+            params={"pageNumber": EXISTING_PAGE_ID},
             timeout=60,
         )
 
@@ -92,7 +94,8 @@ class TestApiTranslationMemory(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.get.value,
             "https://cloud.memsource.com/web/api2/v1/transMemories",
-            params={"token": "mock-token", "pageNumber": EMPTY_PAGE_ID},
+            headers={"Authorization": "ApiToken mock-token"},
+            params={"pageNumber": EMPTY_PAGE_ID},
             timeout=60,
         )
 
@@ -126,9 +129,9 @@ class TestApiTranslationMemory(unittest.TestCase):
                     mock_open.return_value.__enter__.return_value.name,
                 ),
                 "Content-Type": "application/octet-stream",
+                "Authorization": "ApiToken mock-token",
             },
             "data": mock_open.return_value.__enter__.return_value,
-            "params": {"token": "mock-token"},
             "timeout": 60,
         }, called_kwargs)
         self.assertEqual(accepted_segments_count, returned_value)
@@ -165,9 +168,9 @@ class TestApiTranslationMemory(unittest.TestCase):
                     mock_tempfile.return_value.__enter__.return_value.name,
                 ),
                 "Content-Type": "application/octet-stream",
+                "Authorization": "ApiToken mock-token",
             },
             "data": mock_tempfile.return_value.__enter__.return_value,
-            "params": {"token": "mock-token"},
             "timeout": 60,
         }, called_kwargs)
 
@@ -265,7 +268,7 @@ class TestApiTranslationMemory(unittest.TestCase):
                 "https://cloud.memsource.com/web/api2/"
                 "v1/projects/1234/jobs/1/transMemories/searchSegment"
             ),
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             json={
                 "segment": segment,
                 "nextSegment": next_segment,
@@ -368,7 +371,7 @@ class TestApiTranslationMemory(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/transMemories/1234/search",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             json={
                 "query": query,
                 "sourceLang": source_lang,
@@ -426,7 +429,7 @@ class TestApiTranslationMemory(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v2/transMemories/4567/export",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             json={
                 "exportTargetLangs": target_langs,
                 "callbackUrl": callback_url,
@@ -457,7 +460,7 @@ class TestApiTranslationMemory(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.post.value,
             "https://cloud.memsource.com/web/api2/v1/transMemories/1234/segments",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             json={
                 "targetLang": target_lang,
                 "sourceSegment": source_segment,
@@ -481,6 +484,6 @@ class TestApiTranslationMemory(unittest.TestCase):
         mock_request.assert_called_with(
             constants.HttpMethod.delete.value,
             "https://cloud.memsource.com/web/api2/v1/transMemories/1/segments/2",
-            params={"token": "mock-token"},
+            headers={"Authorization": "ApiToken mock-token"},
             timeout=60,
         )


### PR DESCRIPTION
This pull request moves the deprecated "token" in the query string to the "Authorization" header.

See https://support.phrase.com/hc/en-us/articles/5709662181404-API-Authentication-TMS-#token-0-0
