### PR TITLE
removed flake8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ iso8601>=0.1.10
 nose>=1.3.7
 coverage>=3.7.1
 rednose>=0.4.3
-flake8==3.5.0
 lxml>=3.4.4
 mypy-lang>=0.2.0
 typing

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -1,9 +1,6 @@
 #! /bin/bash
 EXIT_STATUSES=()
 
-flake8 .
-EXIT_STATUSES=(${EXIT_STATUSES[@]} $?)
-
 nosetests --with-coverage --cover-package=memsource --rednose
 EXIT_STATUSES=(${EXIT_STATUSES[@]} $?)
 


### PR DESCRIPTION
this memsource-wrap is a dependency for tm-api, and flake8 registered as a dependency prevent tm-api flake8 to be upgraded. since this repo will probably not be maintained anymore I'm just removing flake8 check 